### PR TITLE
Add the option to set the MasterQA verify delay from the command line

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -78,6 +78,10 @@ def pytest_addoption(parser):
                      default=None,
                      help="""Setting this overrides the default number of
                           highlight animation loops to have per call.""")
+    parser.addoption('--verify_delay', action='store', dest='verify_delay',
+                     default=None,
+                     help="""Setting this overrides the default wait time
+                          before each MasterQA verification pop-up.""")
 
 
 def pytest_configure(config):

--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -67,6 +67,7 @@ WAIT_FOR_RSC_ON_CLICKS = False
 MASTERQA_DEFAULT_VALIDATION_MESSAGE = "Does the page look good?"
 
 # The time delay (in seconds) before the validation pop-up appears
+# This value can be overwritten on the command line. Ex: --verify_delay=0.5
 MASTERQA_WAIT_TIME_BEFORE_VERIFY = 1.0
 
 # If True, the automation will start in full-screen mode

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -848,6 +848,7 @@ class BaseCase(unittest.TestCase):
             self.demo_mode = pytest.config.option.demo_mode
             self.demo_sleep = pytest.config.option.demo_sleep
             self.highlights = pytest.config.option.highlights
+            self.verify_delay = pytest.config.option.verify_delay
             if self.with_db_reporting:
                 self.execution_guid = str(uuid.uuid4())
                 self.testcase_guid = None

--- a/seleniumbase/masterqa/master_qa.py
+++ b/seleniumbase/masterqa/master_qa.py
@@ -63,7 +63,10 @@ class __MasterQATestCase__(BaseCase):
             instructions = str(args[0])
 
         # Give the human enough time to see the page first
-        time.sleep(WAIT_TIME_BEFORE_VERIFY)
+        wait_time_before_verify = WAIT_TIME_BEFORE_VERIFY
+        if self.verify_delay:
+            wait_time_before_verify = float(self.verify_delay)
+        time.sleep(wait_time_before_verify)
         question = "Approve?"
         if instructions and "?" not in instructions:
             question = instructions + " Approve?"
@@ -268,7 +271,10 @@ class __MasterQATestCase__(BaseCase):
         self.open("file://%s" % archived_results_file)
         if auto_close_results_page:
             # Long enough to notice the results before closing the page
-            time.sleep(WAIT_TIME_BEFORE_VERIFY)
+            wait_time_before_verify = WAIT_TIME_BEFORE_VERIFY
+            if self.verify_delay:
+                wait_time_before_verify = float(self.verify_delay)
+            time.sleep(wait_time_before_verify)
         else:
             # The user can decide when to close the results page
             print "\n*** Close the html report window to continue ***"

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -18,7 +18,7 @@ class SeleniumBrowser(Plugin):
     The plugin for Selenium tests. Takes in key arguments and then
     creates a WebDriver object. All arguments are passed to the tests.
 
-    The following variables are made to the tests:
+    The following command line options are available to the tests:
     self.options.browser -- the browser to use (--browser)
     self.options.server -- the server used by the test (--server)
     self.options.port -- the port used by the test (--port)
@@ -26,6 +26,7 @@ class SeleniumBrowser(Plugin):
     self.options.demo_mode -- the option to slow down Selenium (--demo_mode)
     self.options.demo_sleep -- Selenium action delay in DemoMode (--demo_sleep)
     self.options.highlights -- # of highlight animations shown (--highlights)
+    self.options.verify_delay -- delay before MasterQA checks (--verify_delay)
     """
     name = 'selenium'  # Usage: --with-selenium
 
@@ -69,6 +70,10 @@ class SeleniumBrowser(Plugin):
                           dest='highlights', default=None,
                           help="""Setting this overrides the default number of
                                highlight animation loops to have per call.""")
+        parser.add_option('--verify_delay', action='store',
+                          dest='verify_delay', default=None,
+                          help="""Setting this overrides the default wait time
+                               before each MasterQA verification pop-up.""")
 
     def configure(self, options, conf):
         super(SeleniumBrowser, self).configure(options, conf)
@@ -126,6 +131,7 @@ class SeleniumBrowser(Plugin):
                 test.test.demo_mode = self.options.demo_mode
                 test.test.demo_sleep = self.options.demo_sleep
                 test.test.highlights = self.options.highlights
+                test.test.verify_delay = self.options.verify_delay  # MasterQA
             except Exception as err:
                 print("Error starting/connecting to Selenium:")
                 print(err)

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 """
-The setup package to install the SeleniumBase Test Framework plugins
+The setup package to install SeleniumBase dependencies and plugins
 """
 
 from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.2.3',
+    version='1.2.4',
     url='http://seleniumbase.com',
     author='Michael Mintz',
     author_email='@mintzworld',


### PR DESCRIPTION
The verify_delay for MasterQA is the number of seconds to pause the screen before each verify() call creates a pop-up for the manual QA tester. The default is 1.0 seconds, which is set in https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py
This delay gives the manual QA tester time to inspect the page freely without the question pop-up.