### PR TITLE
Fix deploy - Keep using Selenium 2 until ready for 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pip>=8.1.2
 setuptools>=28.2.0
-selenium>=2.53.6
+selenium==2.53.6
 nose>=1.3.7
 pytest>=3.0.2
 six>=1.10.0

--- a/server_requirements.txt
+++ b/server_requirements.txt
@@ -1,6 +1,6 @@
 pip>=8.1.2
 setuptools>=28.2.0
-selenium>=2.53.6
+selenium==2.53.6
 nose>=1.3.7
 pytest>=3.0.2
 six>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         'pip>=8.1.2',
         'setuptools>=28.2.0',
-        'selenium>=2.53.6',
+        'selenium==2.53.6',
         'nose>=1.3.7',
         'pytest>=3.0.2',
         'six>=1.10.0',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.2.12',
+    version='1.2.13',
     url='http://seleniumbase.com',
     author='Michael Mintz',
     author_email='@mintzworld',


### PR DESCRIPTION
Use hard selenium version of 2.53.6 because otherwise the latest version of selenium is 3.* and that is causing tests to break due to the new Geckodriver.