### PR TITLE
Update selenium version to fix Firefox browser not starting with profile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip>=9.0.1
 setuptools>=35.0.1
 ipython==5.3.0
-selenium==3.4.0
+selenium==3.4.1
 nose>=1.3.7
 pytest>=3.0.7
 pytest-html>=1.14.2

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -22,17 +22,19 @@ def get_driver(browser_name):
             profile.set_preference(
                 "security.mixed_content.block_active_content", False)
             profile.set_preference(
-                "browser.download.manager.showAlertOnComplete", True)
-            profile.set_preference("browser.download.panel.shown", True)
+                "browser.download.manager.showAlertOnComplete", False)
+            profile.set_preference("browser.download.panel.shown", False)
             profile.set_preference(
-                "browser.download.animateNotifications", True)
+                "browser.download.animateNotifications", False)
             profile.set_preference("browser.download.dir", downloads_path)
             profile.set_preference("browser.download.folderList", 2)
             profile.set_preference(
                 "browser.helperApps.neverAsk.saveToDisk",
                 ("application/pdf, application/zip, application/octet-stream, "
                  "text/csv, text/xml, application/xml, text/plain, "
-                 "text/octet-stream"))
+                 "text/octet-stream",
+                 "application/"
+                 "vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
             firefox_capabilities = DesiredCapabilities.FIREFOX
             try:
                 # Use Geckodriver for Firefox if it's on the PATH

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'pip>=9.0.1',
         'setuptools>=35.0.1',
         'ipython==5.3.0',
-        'selenium==3.4.0',
+        'selenium==3.4.1',
         'nose>=1.3.7',
         'pytest>=3.0.7',
         'pytest-html>=1.14.2',


### PR DESCRIPTION
Also changed the profile setting for download complete animation from default true values to false so clicking on element does not fail due to active download complete animations.  