### PR TITLE
Improve check_assert system

### DIFF
--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -1174,7 +1174,7 @@ class BaseCase(unittest.TestCase):
             non-terminating verifications that only raise exceptions
             after this method is called. This is useful for pages with multiple
             elements to be checked when you want to find as many bugs
-            as possible in a single test run before having 
+            as possible in a single test run before having
             all the exceptions get raised simultaneously.
             Might be more useful if this method is called after processing
             all the checks on a single html page so that the failure screenshot

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -1169,15 +1169,17 @@ class BaseCase(unittest.TestCase):
             self._package_check()
             return False
 
-    def process_checks(self):
-        """ To be used at the end of any test that uses checks, which are
-            non-terminating verifications that will only raise an exception
-            after this method is called. Useful for pages with multiple
-            elements to be checked when you want to find as many failures
-            as possible on a page before making fixes.
+    def process_checks(self, print_only=False):
+        """ To be used with any test that uses check_asserts, which are
+            non-terminating verifications that only raise exceptions
+            after this method is called. This is useful for pages with multiple
+            elements to be checked when you want to find as many bugs
+            as possible in a single test run before having 
+            all the exceptions get raised simultaneously.
             Might be more useful if this method is called after processing
-            all the checks for a single html page, otherwise the screenshot
-            in the logs file won't match the location of the checks. """
+            all the checks on a single html page so that the failure screenshot
+            matches the location of the checks.
+            If "print_only" is set to True, the exception won't get raised. """
         if self.page_check_failures:
             exception_output = ''
             exception_output += "\n*** FAILED CHECKS FOR: %s\n" % self.id()
@@ -1185,7 +1187,10 @@ class BaseCase(unittest.TestCase):
             self.page_check_failures = []
             for tb in all_failing_checks:
                 exception_output += "%s\n" % tb
-            raise Exception(exception_output)
+            if print_only:
+                print(exception_output)
+            else:
+                raise Exception(exception_output)
 
     ############
 
@@ -1397,19 +1402,19 @@ class BaseCase(unittest.TestCase):
 
     def tearDown(self):
         """
-        pytest-specific code
         Be careful if a subclass of BaseCase overrides setUp()
         You'll need to add the following line to the subclass's tearDown():
         super(SubClassOfBaseCase, self).tearDown()
         """
         if self.page_check_failures:
-            # self.process_checks() was not called after checks were made.
-            # We will log those now here, but without raising an exception.
-            exception_output = ''
-            exception_output += "\n*** FAILED CHECKS FOR: %s\n" % self.id()
-            for tb in self.page_check_failures:
-                exception_output += "%s\n" % tb
-            logging.exception(exception_output)
+            print(
+                "\nWhen using self.check_assert_***() methods in your tests, "
+                "remember to call self.process_checks() afterwards. "
+                "Now calling in tearDown()...\nFailures Detected:")
+            if not sys.exc_info()[1]:
+                self.process_checks()
+            else:
+                self.process_checks(print_only=True)
         self.is_pytest = None
         try:
             # This raises an exception if the test is not coming from pytest
@@ -1418,6 +1423,7 @@ class BaseCase(unittest.TestCase):
             # Not using pytest (probably nosetests)
             self.is_pytest = False
         if self.is_pytest:
+            # pytest-specific code
             test_id = "%s.%s.%s" % (self.__class__.__module__,
                                     self.__class__.__name__,
                                     self._testMethodName)

--- a/seleniumbase/plugins/base_plugin.py
+++ b/seleniumbase/plugins/base_plugin.py
@@ -81,6 +81,7 @@ class Base(Plugin):
                 shutil.rmtree(archived_logs)
         self.successes = []
         self.failures = []
+        self.start_time = float(0)
         self.duration = float(0)
         self.page_results_list = []
         self.test_count = 0
@@ -96,7 +97,7 @@ class Base(Plugin):
         test.test.data = self.options.data
         test.test.args = self.options
         self.test_count += 1
-        self.duration = float(time.time())
+        self.start_time = float(time.time())
 
     def finalize(self, result):
         if self.report_on:
@@ -128,7 +129,7 @@ class Base(Plugin):
     def addSuccess(self, test, capt):
         if self.report_on:
             self.duration = str(
-                "%0.3fs" % (float(time.time()) - float(self.duration)))
+                "%0.3fs" % (float(time.time()) - float(self.start_time)))
             self.successes.append(test.id())
             self.page_results_list.append(
                 report_helper.process_successes(
@@ -137,7 +138,7 @@ class Base(Plugin):
     def add_fails_or_errors(self, test):
         if self.report_on:
             self.duration = str(
-                "%0.3fs" % (float(time.time()) - float(self.duration)))
+                "%0.3fs" % (float(time.time()) - float(self.start_time)))
             if test.id() == 'nose.failure.Failure.runTest':
                 print(">>> ERROR: Could not locate tests to run!")
                 print(">>> The Test Report WILL NOT be generated!")

--- a/server_setup.py
+++ b/server_setup.py
@@ -14,7 +14,7 @@ setup(
     platforms='Mac * Windows * Linux * Docker',
     url='http://seleniumbase.com',
     author='Michael Mintz',
-    author_email='@mintzworld',
+    author_email='mdmintz@gmail.com',
     maintainer='Michael Mintz',
     license='The MIT License',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.3.25',
+    version='1.3.26',
     description='Test Automation Framework - http://seleniumbase.com',
     long_description='Automation Framework for Simple & Reliable Web Testing',
     platforms='Mac * Windows * Linux * Docker',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     platforms='Mac * Windows * Linux * Docker',
     url='http://seleniumbase.com',
     author='Michael Mintz',
-    author_email='@mintzworld',
+    author_email='mdmintz@gmail.com',
     maintainer='Michael Mintz',
     license='The MIT License',
     install_requires=[


### PR DESCRIPTION
The check_assert system may have been confusing to SeleniumBase users. It was built to allow a test to make multiple assertions on a page without raising any test failures until all desired check_asserts were called and then self.process_checks() called after that.

The check_asserts include self.check_assert_element() and self.check_assert_text().

Rather than fail a test immediately after the first assertion failure, the test failure is delayed until later when more assertions have been made. The issue arose when SeleniumBase users called the check_assert methods in their tests without calling self.process_checks() afterward. This led to tests that had failed assertions that were never raised at the end of the test, giving the test a Pass instead of a Fail when it should be failing. Now, self.process_checks() will automatically get called in the tearDown() phase at the end of each test if there are any check_assert exceptions that were never raised by a self.process_checks() call from inside the test.