### PR TITLE
Minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,24 +88,22 @@ cd SeleniumBase
 
 If you're installing SeleniumBase from a cloned copy on your machine, use:
 ```
-pip install -r requirements.txt
+pip install -U -r requirements.txt
 
 python setup.py develop
 ```
 
 If you're installing SeleniumBase from the [Python Package Index](https://pypi.python.org/pypi/seleniumbase), use:
 ```bash
-pip install seleniumbase
+pip install -U seleniumbase
 ```
 
 If you're installing SeleniumBase directly from GitHub, use:
 ```bash
-pip install -e git+https://github.com/seleniumbase/SeleniumBase.git@master#egg=seleniumbase
+pip install -U -e git+https://github.com/seleniumbase/SeleniumBase.git@master#egg=seleniumbase
 ```
 
-(If you already have an older version installed, you may want to add ``--upgrade`` to your ``pip`` command to update existing Python packages. If you're not using a virtual environment, you may need to add ``--user`` to your ``pip`` command if you're getting errors during installation.)
-
-(If you want to use Python 3.x instead of Python 2.7, use ``pip3`` in place of ``pip`` and ``python3`` in place of ``python``.)
+(If you encounter permission errors during installation while not using a virtual environment, you may need to add ``--user`` to your ``pip`` command.)
 
 
 <a id="seleniumbase_basic_usage"></a>

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -1376,7 +1376,7 @@ class BaseCase(unittest.TestCase):
             timeout = self._get_new_timeout(timeout)
         is_ready = page_actions.wait_for_ready_state_complete(self.driver,
                                                               timeout)
-        self.wait_for_angularjs()
+        self.wait_for_angularjs(timeout=settings.MINI_TIMEOUT)
         return is_ready
 
     def wait_for_angularjs(self, timeout=settings.LARGE_TIMEOUT, **kwargs):

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -698,8 +698,8 @@ class BaseCase(unittest.TestCase):
             '''script.src = "http://code.jquery.com/jquery-3.2.1.min.js"; '''
             '''document.getElementsByTagName("head")[0]'''
             '''.appendChild(script);''')
-        for x in range(30):
-            # jQuery needs a small amount of time to activate. (At most 3s)
+        for x in range(int(settings.MINI_TIMEOUT * 10.0)):
+            # jQuery needs a small amount of time to activate.
             try:
                 self.execute_script("jQuery('html')")
                 return

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.8.1',
+    version='1.8.2',
     description='Web Automation & Testing Framework - http://seleniumbase.com',
     long_description='Web Automation and Testing Framework - seleniumbase.com',
     platforms='Mac * Windows * Linux * Docker',


### PR DESCRIPTION
* Use plain javascript instead of jQuery when highlighting elements because some websites (such as GitHub) have Content Security Policy directives that prevent loading jQuery for custom scripts.

* If waiting for angularjs to load as part of ready state, wait less time

* Set maximum time for activating jQuery to be settings.MINI_TIMEOUT 