### PR TITLE
Use Python standard library methods when possible

### DIFF
--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -114,8 +114,6 @@ self.remove_element(selector, by=By.CSS_SELECTOR)
 
 self.remove_elements(selector, by=By.CSS_SELECTOR)
 
-self.jq_format(code)
-
 self.get_domain_url(url)
 
 self.safe_execute_script(script)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytest-xdist==1.22.2
 six==1.10.0
 flake8==3.5.0
 requests==2.18.4
-BeautifulSoup4==4.6.0
+beautifulsoup4==4.6.0
 unittest2==1.1.0
 chardet==3.0.4
 boto==2.48.0

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -27,6 +27,7 @@ import logging
 import math
 import os
 import pytest
+import re
 import sys
 import time
 import traceback
@@ -549,7 +550,7 @@ class BaseCase(unittest.TestCase):
         if (retry and element.get_attribute('value') != new_value and (
                 not new_value.endswith('\n'))):
             logging.debug('update_text_value is falling back to jQuery!')
-            selector = self.jq_format(selector)
+            selector = re.escape(selector)
             self.set_value(selector, new_value, by=by)
         if self.demo_mode:
             if self.driver.current_url != pre_action_url:
@@ -731,7 +732,7 @@ class BaseCase(unittest.TestCase):
             raise Exception(
                 "Exception: Could not convert {%s}(by=%s) to CSS_SELECTOR!" % (
                     selector, by))
-        selector = self.jq_format(selector)
+        selector = re.escape(selector)
         script = ("""var $elm = document.querySelector('%s');
                   $val = window.getComputedStyle($elm).getPropertyValue('%s');
                   return $val;"""
@@ -755,7 +756,7 @@ class BaseCase(unittest.TestCase):
         except Exception:
             # Don't run action if can't convert to CSS_Selector for JavaScript
             return
-        selector = self.jq_format(selector)
+        selector = re.escape(selector)
         script = ("""document.querySelector('%s').style.zIndex = "100";"""
                   % selector)
         self.execute_script(script)
@@ -796,11 +797,11 @@ class BaseCase(unittest.TestCase):
                 o_bs = original_box_shadow
 
         if ":contains" not in selector and ":first" not in selector:
-            selector = self.jq_format(selector)
+            selector = re.escape(selector)
             self.__highlight_with_js(selector, loops, scroll, o_bs)
         else:
             selector = self._make_css_match_first_element_only(selector)
-            selector = self.jq_format(selector)
+            selector = re.escape(selector)
             try:
                 self.__highlight_with_jquery(selector, loops, scroll, o_bs)
             except Exception:
@@ -978,7 +979,8 @@ class BaseCase(unittest.TestCase):
         self.safe_execute_script(remove_script)
 
     def jq_format(self, code):
-        return page_utils.jq_format(code)
+        # DEPRECATED - Use re.escape() instead, which does the action you want.
+        return page_utils._jq_format(code)
 
     def get_domain_url(self, url):
         return page_utils.get_domain_url(url)
@@ -1087,7 +1089,7 @@ class BaseCase(unittest.TestCase):
         selector = self.convert_to_css_selector(selector, by=by)
         selector = self._make_css_match_first_element_only(selector)
         update_text_script = """jQuery('%s').val('%s')""" % (
-            selector, self.jq_format(new_value))
+            selector, re.escape(new_value))
         self.safe_execute_script(update_text_script)
         if new_value.endswith('\n'):
             element.send_keys('\n')

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -1058,11 +1058,14 @@ class BaseCase(unittest.TestCase):
 
     def set_value(self, selector, new_value, by=By.CSS_SELECTOR,
                   timeout=settings.LARGE_TIMEOUT):
-        """ This method uses jQuery to update a text field. """
+        """ This method uses jQuery to update a text field.
+            Similar to jquery_update_text_value(), but the element
+            doesn't need to be officially visible to work. """
         if self.timeout_multiplier and timeout == settings.LARGE_TIMEOUT:
             timeout = self._get_new_timeout(timeout)
         if page_utils.is_xpath_selector(selector):
             by = By.XPATH
+        orginal_selector = selector
         selector = self.convert_to_css_selector(selector, by=by)
         self._demo_mode_highlight_if_active(selector, by)
         self.scroll_to(selector, by=by, timeout=timeout)
@@ -1070,6 +1073,10 @@ class BaseCase(unittest.TestCase):
         selector = self._make_css_match_first_element_only(selector)
         set_value_script = """jQuery('%s').val(%s)""" % (selector, value)
         self.safe_execute_script(set_value_script)
+        if new_value.endswith('\n'):
+            element = self.wait_for_element_present(
+                orginal_selector, by=by, timeout=timeout)
+            element.send_keys(Keys.RETURN)
         self._demo_mode_pause_if_active()
 
     def jquery_update_text_value(self, selector, new_value, by=By.CSS_SELECTOR,

--- a/seleniumbase/fixtures/page_utils.py
+++ b/seleniumbase/fixtures/page_utils.py
@@ -5,19 +5,6 @@ import re
 import requests
 
 
-def jq_format(code):
-    """
-    Use before throwing raw code such as 'div[tab="advanced"]' into jQuery.
-    Selectors with quotes inside of quotes would otherwise break jQuery.
-    This is similar to "json.dumps(value)", but with one less layer of quotes.
-    """
-    code = code.replace('\\', '\\\\').replace('\t', '\\t').replace('\n', '\\n')
-    code = code.replace('\"', '\\\"').replace('\'', '\\\'')
-    code = code.replace('\v', '\\v').replace('\a', '\\a').replace('\f', '\\f')
-    code = code.replace('\b', '\\b').replace(r'\u', '\\u').replace('\r', '\\r')
-    return code
-
-
 def get_domain_url(url):
     """
     Use this to convert a url like this:
@@ -87,3 +74,17 @@ def _download_file_to(file_url, destination_folder, new_file_name=None):
     r = requests.get(file_url)
     with open(destination_folder + '/' + file_name, "wb") as code:
         code.write(r.content)
+
+
+def _jq_format(code):
+    """
+    DEPRECATED - Use re.escape() instead, which performs the intended action.
+    Use before throwing raw code such as 'div[tab="advanced"]' into jQuery.
+    Selectors with quotes inside of quotes would otherwise break jQuery.
+    This is similar to "json.dumps(value)", but with one less layer of quotes.
+    """
+    code = code.replace('\\', '\\\\').replace('\t', '\\t').replace('\n', '\\n')
+    code = code.replace('\"', '\\\"').replace('\'', '\\\'')
+    code = code.replace('\v', '\\v').replace('\a', '\\a').replace('\f', '\\f')
+    code = code.replace('\b', '\\b').replace(r'\u', '\\u').replace('\r', '\\r')
+    return code

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'six==1.10.0',
         'flake8==3.5.0',
         'requests==2.18.4',
-        'BeautifulSoup4==4.6.0',
+        'beautifulsoup4==4.6.0',
         'unittest2==1.1.0',
         'chardet==3.0.4',
         'boto==2.48.0',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.8.3',
+    version='1.8.4',
     description='Web Automation & Testing Framework - http://seleniumbase.com',
     long_description='Web Automation and Testing Framework - seleniumbase.com',
     platforms='Mac * Windows * Linux * Docker',


### PR DESCRIPTION
Use Python standard library methods when possible:

I'm replacing an old method I wrote a long time ago called jq_format() with a Python standard library method that I probably didn't know about then, called re.escape(), which performs the same intended action.