### PR TITLE
Console script updates and driver updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Compiled Python Bytecode
 *.py[cod]
 
 # Packages
@@ -35,23 +36,34 @@ nosetests.xml
 .project
 .pydevproject
 
-# Other
-selenium-server-standalone.jar
-verbose_hub_server.dat
-verbose_node_server.dat
-ip_of_grid_hub.dat
-geckodriver.log
-downloaded_files
-archived_files
+# Web Drivers
+chromedriver
+geckodriver
+MicrosoftWebDriver.exe
+chromedriver.exe
+geckodriver.exe
+
+# Logs
 logs
 latest_logs
 log_archives
 archived_logs
+geckodriver.log
+
+# Reports
 latest_report
 report_archives
 archived_reports
 html_report.html
 report.html
+
+# Other
+selenium-server-standalone.jar
+verbose_hub_server.dat
+verbose_node_server.dat
+ip_of_grid_hub.dat
+downloaded_files
+archived_files
 assets
 temp
 temp*

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,11 @@ install:
   - "sudo rm -f /etc/boto.cfg"
 before_script:
   - "flake8 seleniumbase/*.py && flake8 seleniumbase/*/*.py && flake8 seleniumbase/*/*/*.py && flake8 seleniumbase/*/*/*/*.py"
-  - "wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip && unzip chromedriver_linux64.zip && sudo cp chromedriver /usr/local/bin/ && sudo chmod +x /usr/local/bin/chromedriver"
-  - "wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz -O /tmp/geckodriver.tar.gz && tar -C /opt -xzf /tmp/geckodriver.tar.gz && sudo chmod 755 /opt/geckodriver && sudo ln -fs /opt/geckodriver /usr/bin/geckodriver && sudo ln -fs /opt/geckodriver /usr/local/bin/geckodriver"
+  # - "wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip && unzip chromedriver_linux64.zip && sudo cp chromedriver /usr/local/bin/ && sudo chmod +x /usr/local/bin/chromedriver"
+  # - "wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz -O /tmp/geckodriver.tar.gz && tar -C /opt -xzf /tmp/geckodriver.tar.gz && sudo chmod 755 /opt/geckodriver && sudo ln -fs /opt/geckodriver /usr/bin/geckodriver && sudo ln -fs /opt/geckodriver /usr/local/bin/geckodriver"
   # - "wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 && tar -xvf ./phantomjs-2.1.1-linux-x86_64.tar.bz2 && export PATH=$PWD/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "seleniumbase install chromedriver"
+  - "seleniumbase install geckodriver"
 script:
   - "pytest examples/my_first_test.py --browser=chrome -s --headless --with-db_reporting"
   - "nosetests examples/boilerplates/boilerplate_test.py --browser=chrome --headless"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ install:
   - "sudo rm -f /etc/boto.cfg"
 before_script:
   - "flake8 seleniumbase/*.py && flake8 seleniumbase/*/*.py && flake8 seleniumbase/*/*/*.py && flake8 seleniumbase/*/*/*/*.py"
-  - "wget https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip && unzip chromedriver_linux64.zip && sudo cp chromedriver /usr/local/bin/ && sudo chmod +x /usr/local/bin/chromedriver"
-  - "wget https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-linux64.tar.gz -O /tmp/geckodriver.tar.gz && tar -C /opt -xzf /tmp/geckodriver.tar.gz && sudo chmod 755 /opt/geckodriver && sudo ln -fs /opt/geckodriver /usr/bin/geckodriver && sudo ln -fs /opt/geckodriver /usr/local/bin/geckodriver"
+  - "wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip && unzip chromedriver_linux64.zip && sudo cp chromedriver /usr/local/bin/ && sudo chmod +x /usr/local/bin/chromedriver"
+  - "wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz -O /tmp/geckodriver.tar.gz && tar -C /opt -xzf /tmp/geckodriver.tar.gz && sudo chmod 755 /opt/geckodriver && sudo ln -fs /opt/geckodriver /usr/bin/geckodriver && sudo ln -fs /opt/geckodriver /usr/local/bin/geckodriver"
   # - "wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 && tar -xvf ./phantomjs-2.1.1-linux-x86_64.tar.bz2 && export PATH=$PWD/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
 script:
   - "pytest examples/my_first_test.py --browser=chrome -s --headless --with-db_reporting"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ SeleniumBase was originally built for [testing HubSpot's platform](https://produ
 
 ## Get Started:
 
-Before installation, **[install Python](https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/install_python_pip_git.md)** and **[get a WebDriver](https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/webdriver_installation.md)** on your system PATH.
+Before installation, **[install Python](https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/install_python_pip_git.md)** and **[install a web driver](https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/webdriver_installation.md)**.
 
 
 ### ![http://seleniumbase.com](https://cdn2.hubspot.net/hubfs/100006/images/super_logo_tiny.png "SeleniumBase") **Step 1:** Clone SeleniumBase
@@ -151,32 +151,23 @@ If the example test is moving too fast for your eyes to see what's going on, you
 pytest my_first_test.py --demo_mode
 ```
 
-You can override the default wait time by either updating [settings.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py) or by using ``--demo_sleep={NUM}`` when using Demo Mode. (NOTE: If you use ``--demo_sleep={NUM}`` without using ``--demo_mode``, nothing will happen.)
-
-```bash
-pytest my_first_test.py --demo_mode --demo_sleep=1.2
-```
-
-You can also use the following in your scripts to slow down the tests:
+You can use the following in your scripts to help you debug issues::
 
 ```python
 import time; time.sleep(5)  # sleep for 5 seconds (add this after the line you want to pause on)
 import ipdb; ipdb.set_trace()  # waits for your command. n = next line of current method, c = continue, s = step / next executed line (will jump)
+import pytest; pytest.set_trace()  # similar to ipdb, but specific to pytest
 ```
 
-(NOTE: If you're using pytest instead of nosetests and you want to use ipdb in your script for debugging purposes, you'll need to add ``--capture=no`` (or ``-s``) on the command line, or use ``import pytest; pytest.set_trace()`` instead of using ipdb. More info on that [here](http://stackoverflow.com/questions/2678792/can-i-debug-with-python-debugger-when-using-py-test-somehow).)
-
-You may also want to have your test sleep in other situations where you need to have your test wait for something. If you know what you're waiting for, you should be specific by using a command that waits for something specific to happen.
-
-If you need to debug things on the fly (in case of errors), use this:
+**To pause an active test that throws an exception or error, add ``--pdb --pdb-failures -s``:**
 
 ```bash
 pytest my_first_test.py --browser=chrome --pdb --pdb-failures -s
 ```
 
-The above code (with --pdb) will leave your browser window open in case there's a failure, which is possible if the web pages from the example change the data that's displayed on the page. (ipdb commands: 'c', 's', 'n' => continue, step, next). You may need the ``-s`` in order to see all console output.
+The code above will leave your browser window open in case there's a failure. (ipdb commands: 'c', 's', 'n' => continue, step, next).
 
-Here are some other useful nosetest arguments for appending to your run commands:
+Here are some other useful **nosetest**-specific arguments:
 
 ```bash
 --logging-level=INFO  # Hide DEBUG messages, which can be overwhelming.
@@ -185,7 +176,7 @@ Here are some other useful nosetest arguments for appending to your run commands
 --with-id  # If -v is also used, will number the tests for easy counting.
 ```
 
-During test failures you'll get detailed log files, which include screenshots, page source, and basic test info, which will get added to the logs folder at ``latest_logs/``. (Unless you have ARCHIVE_EXISTING_LOGS set to True in [settings.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py), log files with be cleaned up at the start of the next test run. If the archive feature is enabled, those logs will get saved to the ``archived_logs/`` folder.) The ``my_test_suite.py`` collection contains tests that fail on purpose so that you can see how logging works.
+During test failures, logs and screenshots from the most recent test run will get saved to the ``latest_logs/`` folder. Those logs will get moved to ``archived_logs/`` if you have ARCHIVE_EXISTING_LOGS set to True in [settings.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py), otherwise log files with be cleaned up at the start of the next test run. The ``my_test_suite.py`` collection contains tests that fail on purpose so that you can see how logging works.
 
 ```bash
 cd examples/
@@ -210,7 +201,7 @@ To run Pytest multithreaded on multiple CPUs at the same time, add ``-n=NUM`` or
 <a id="creating_visual_reports"></a>
 ### ![http://seleniumbase.com](https://cdn2.hubspot.net/hubfs/100006/images/super_logo_tiny.png "SeleniumBase") **Creating Visual Test Suite Reports:**
 
-(NOTE: The command line args are different for Pytest vs Nosetests)
+(NOTE: Several command line args are different for Pytest vs Nosetests)
 
 #### **Pytest Reports:**
 

--- a/console_scripts/ReadMe.md
+++ b/console_scripts/ReadMe.md
@@ -1,9 +1,31 @@
 ## Console Scripts
 
+SeleniumBase console scripts help you get things done more easily, such as installing web drivers, creating a test directory with necessary configuration files, converting old Webdriver unittest scripts into SeleniumBase code, and using the Selenium Grid.
+
+For running tests from the command line, [use **pytest** with SeleniumBase](https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/customizing_test_runs.md).
+
+### install
+
+* Usage:
+``seleniumbase install [DRIVER_NAME]``
+        (Drivers: chromedriver, geckodriver, edgedriver)
+
+* Example:
+``seleniumbase install chromedriver``
+
+* Output:
+Installs the specified webdriver.
+(chromedriver is required for Google Chrome automation)
+(geckodriver is required for Mozilla Firefox automation)
+(edgedriver is required for Microsoft Edge automation)
+
 ### mkdir
 
 * Usage:
 ``seleniumbase mkdir [DIRECTORY_NAME]``
+
+* Example:
+``seleniumbase mkdir gui_tests``
 
 * Output:
 Creates a new folder for running SeleniumBase scripts.
@@ -15,7 +37,7 @@ test frameworks.
 ### convert
 
 * Usage:
-``seleniumbase convert [MY_TEST.py]``
+``seleniumbase convert [PYTHON_WEBDRIVER_UNITTEST_FILE]``
 
 * Output:
 Converts a Selenium IDE exported WebDriver unittest

--- a/console_scripts/run.py
+++ b/console_scripts/run.py
@@ -5,14 +5,16 @@ Usage:
 seleniumbase [COMMAND] [PARAMETERS]
 
 Examples:
-seleniumbase mkdir [DIRECTORY_NAME]
-seleniumbase convert [PYTHON_WEBDRIVER_UNITTEST_FILE]
+seleniumbase install chromedriver
+seleniumbase mkdir gui_tests
+seleniumbase convert my_old_webdriver_unittest.py
 seleniumbase grid-hub start
 seleniumbase grid-node start --hub=127.0.0.1
 """
 
 import sys
 from console_scripts import sb_mkdir
+from console_scripts import sb_install
 from integrations.selenium_grid import grid_hub
 from integrations.selenium_grid import grid_node
 from integrations.selenium_ide import convert_ide
@@ -32,10 +34,27 @@ def show_basic_usage():
     print("")
     print("Commands:")
     print("")
+    print("    install [DRIVER_NAME]")
     print("    mkdir [NEW_TEST_DIRECTORY_NAME]")
     print("    convert [PYTHON_WEBDRIVER_UNITTEST_FILE]")
     print("    grid-hub {start|stop|restart} [OPTIONS]")
     print("    grid-node {start|stop|restart} --hub=[HUB_IP] [OPTIONS]")
+    print("")
+
+
+def show_install_usage():
+    print("  ** install **")
+    print("")
+    print("  Usage:")
+    print("            seleniumbase install [DRIVER_NAME]")
+    print("                  (Drivers: chromedriver, geckodriver, edgedriver)")
+    print("  Example:")
+    print("            seleniumbase install chromedriver")
+    print("  Output:")
+    print("            Installs the specified webdriver.")
+    print("            (chromedriver is required for Chrome automation)")
+    print("            (geckodriver is required for Firefox automation)")
+    print("            (edgedriver is required for MS Edge automation)")
     print("")
 
 
@@ -44,6 +63,8 @@ def show_mkdir_usage():
     print("")
     print("  Usage:")
     print("            seleniumbase mkdir [DIRECTORY_NAME]")
+    print("  Example:")
+    print("            seleniumbase mkdir gui_tests")
     print("  Output:")
     print("            Creates a new folder for running SeleniumBase scripts.")
     print("            The new folder contains default config files,")
@@ -105,6 +126,7 @@ def show_detailed_help():
     show_basic_usage()
     print("More Info:")
     print("")
+    show_install_usage()
     show_mkdir_usage()
     show_convert_usage()
     show_grid_hub_usage()
@@ -123,14 +145,20 @@ def main():
         command = sys.argv[1]
         command_args = sys.argv[2:]
 
-    if command == "convert":
+    if command == "install":
+        if len(command_args) >= 1:
+            sb_install.main()
+        else:
+            show_basic_usage()
+            show_install_usage()
+    elif command == "convert":
         if len(command_args) == 1:
             convert_ide.main()
         else:
             show_basic_usage()
             show_convert_usage()
     elif command == "mkdir":
-        if len(command_args) == 1:
+        if len(command_args) >= 1:
             sb_mkdir.main()
         else:
             show_basic_usage()
@@ -149,7 +177,11 @@ def main():
             show_grid_node_usage()
     elif command == "help" or command == "--help":
         if len(command_args) >= 1:
-            if command_args[0] == "mkdir":
+            if command_args[0] == "install":
+                print("")
+                show_install_usage()
+                return
+            elif command_args[0] == "mkdir":
                 print("")
                 show_mkdir_usage()
                 return

--- a/console_scripts/sb_install.py
+++ b/console_scripts/sb_install.py
@@ -1,0 +1,196 @@
+"""
+Installs the specified web driver.
+
+Usage:
+        seleniumbase install {chromedriver|geckodriver|edgedriver}
+Output:
+        Installs the specified webdriver.
+        (chromedriver is required for Chrome automation)
+        (geckodriver is required for Firefox automation)
+        (edgedriver is required for MS Edge automation)
+"""
+
+import os
+import platform
+import requests
+import sys
+import tarfile
+import zipfile
+import drivers  # webdriver storage folder for SeleniumBase
+if sys.version_info[0] == 2:
+    from urllib import urlopen
+else:
+    from urllib.request import urlopen
+DRIVER_DIR = os.path.dirname(os.path.realpath(drivers.__file__))
+
+
+def invalid_run_command():
+    exp = ("  ** install **\n\n")
+    exp += "  Usage:\n"
+    exp += "          seleniumbase install [DRIVER_NAME]\n"
+    exp += "              (Drivers: chromedriver, geckodriver, edgedriver)\n"
+    exp += "  Example:\n"
+    exp += "          seleniumbase install chromedriver\n"
+    exp += "  Output:\n"
+    exp += "          Installs the specified webdriver.\n"
+    exp += "          (chromedriver is required for Chrome automation)\n"
+    exp += "          (geckodriver is required for Firefox automation)\n"
+    exp += "          (edgedriver is required for MS Edge automation)\n"
+    print("")
+    raise Exception('INVALID RUN COMMAND!\n\n%s' % exp)
+
+
+def make_executable(file_path):
+    # Set permissions to: "If you can read it, you can execute it."
+    mode = os.stat(file_path).st_mode
+    mode |= (mode & 0o444) >> 2  # copy R bits to X
+    os.chmod(file_path, mode)
+
+
+def main():
+    num_args = len(sys.argv)
+    if sys.argv[0].split('/')[-1] == "seleniumbase" or (
+            sys.argv[0].split('\\')[-1] == "seleniumbase"):
+        if num_args < 3 or num_args > 3:
+            invalid_run_command()
+    else:
+        invalid_run_command()
+    name = sys.argv[num_args-1]
+
+    file_name = None
+    download_url = None
+    downloads_folder = DRIVER_DIR
+
+    if name == "chromedriver":
+        if "darwin" in sys.platform:
+            file_name = "chromedriver_mac64.zip"
+        elif "linux" in sys.platform:
+            file_name = "chromedriver_linux64.zip"
+        elif "win32" in sys.platform or "win64" in sys.platform:
+            file_name = "chromedriver_win32.zip"  # Works for win32 and win64
+        else:
+            raise Exception("Cannon determine which version of Chromedriver "
+                            "to download!")
+
+        latest_version = requests.get(
+            "http://chromedriver.storage.googleapis.com/LATEST_RELEASE").text
+        download_url = ("http://chromedriver.storage.googleapis.com/"
+                        "%s/%s" % (latest_version, file_name))
+        print('\nLocating the latest version of Chromedriver...')
+        if not requests.get(download_url).ok:
+            # If there's a problem with the latest Chromedriver, fall back
+            fallback_version = "2.41"
+            download_url = ("http://chromedriver.storage.googleapis.com/"
+                            "%s/%s" % (fallback_version, file_name))
+        print("Found %s" % download_url)
+    elif name == "geckodriver" or name == "firefoxdriver":
+        latest_version = "v0.21.0"
+        if "darwin" in sys.platform:
+            file_name = "geckodriver-%s-macos.tar.gz" % latest_version
+        elif "linux" in sys.platform:
+            arch = platform.architecture()[0]
+            if "64" in arch:
+                file_name = "geckodriver-%s-linux64.tar.gz" % latest_version
+            else:
+                file_name = "geckodriver-%s-linux32.tar.gz" % latest_version
+        elif "win32" in sys.platform:
+            file_name = "geckodriver-%s-win32.zip" % latest_version
+        elif "win64" in sys.platform:
+            file_name = "geckodriver-%s-win64.zip" % latest_version
+        else:
+            raise Exception("Cannon determine which version of Geckodriver "
+                            "(Firefox Driver) to download!")
+
+        download_url = ("http://github.com/mozilla/geckodriver/"
+                        "releases/download/"
+                        "%s/%s" % (latest_version, file_name))
+    elif name == "edgedriver" or name == "microsoftwebdriver":
+        if "win32" in sys.platform or "win64" in sys.platform:
+            version_code = "F/8/A/F8AF50AB-3C3A-4BC4-8773-DC27B32988DD"
+            file_name = "MicrosoftWebDriver.exe"
+            download_url = ("https://download.microsoft.com/download/"
+                            "%s/%s" % (version_code, file_name))
+        else:
+            raise Exception("Sorry! Microsoft WebDriver / EdgeDriver is "
+                            "only for Windows-based operating systems!")
+    else:
+        invalid_run_command()
+
+    if file_name is None or download_url is None:
+        invalid_run_command()
+
+    file_path = downloads_folder + '/' + file_name
+    if not os.path.exists(downloads_folder):
+        os.mkdir(downloads_folder)
+    local_file = open(file_path, 'wb')
+    remote_file = urlopen(download_url)
+    print('\nDownloading %s from:\n%s ...' % (file_name, download_url))
+    local_file.write(remote_file.read())
+    local_file.close()
+    remote_file.close()
+    print('Download Complete!\n')
+
+    if file_name.endswith(".zip"):
+        zip_file_path = file_path
+        zip_ref = zipfile.ZipFile(zip_file_path, 'r')
+        contents = zip_ref.namelist()
+        if len(contents) == 1:
+            for f_name in contents:
+                # remove existing version if exists
+                new_file = downloads_folder + '/' + str(f_name)
+                if "Driver" in new_file or "driver" in new_file:
+                    if os.path.exists(new_file):
+                        os.remove(new_file)  # Technically the old file now
+            print('Extracting %s from %s ...' % (contents, file_name))
+            zip_ref.extractall(downloads_folder)
+            zip_ref.close()
+            os.remove(zip_file_path)
+            print('Unzip Complete!\n')
+            for f_name in contents:
+                new_file = downloads_folder + '/' + str(f_name)
+                print("%s saved!\n" % new_file)
+                print("Making %s executable ..." % new_file)
+                make_executable(new_file)
+                print("%s is now ready for use!" % new_file)
+            print("")
+        elif len(contents) == 0:
+            raise Exception("Zip file %s is empty!" % zip_file_path)
+        else:
+            raise Exception("Expecting only one file in %s!" % zip_file_path)
+    elif file_name.endswith(".tar.gz"):
+        tar_file_path = file_path
+        tar = tarfile.open(file_path)
+        contents = tar.getnames()
+        if len(contents) == 1:
+            for f_name in contents:
+                # remove existing version if exists
+                new_file = downloads_folder + '/' + str(f_name)
+                if "Driver" in new_file or "driver" in new_file:
+                    if os.path.exists(new_file):
+                        os.remove(new_file)  # Technically the old file now
+            print('Extracting %s from %s ...' % (contents, file_name))
+            tar.extractall(downloads_folder)
+            tar.close()
+            os.remove(tar_file_path)
+            print('Untar Complete!\n')
+            for f_name in contents:
+                new_file = downloads_folder + '/' + str(f_name)
+                print("%s saved!\n" % new_file)
+                print("Making %s executable ..." % new_file)
+                make_executable(new_file)
+                print("%s is now ready for use!" % new_file)
+            print("")
+        elif len(contents) == 0:
+            raise Exception("Tar file %s is empty!" % tar_file_path)
+        else:
+            raise Exception("Expecting only one file in %s!" % tar_file_path)
+    else:
+        # Not a .zip file or a .tar.gz file. Just a direct download.
+        if "Driver" in file_name or "driver" in file_name:
+            print("Making %s executable ..." % file_path)
+            make_executable(file_path)
+            print("%s is now ready for use!\n" % file_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/console_scripts/sb_mkdir.py
+++ b/console_scripts/sb_mkdir.py
@@ -4,8 +4,11 @@ Creates a new folder for running SeleniumBase scripts.
 Usage:
 seleniumbase mkdir [DIRECTORY_NAME]
 Output:
-A new folder for running SeleniumBase scripts.
-Contains default config files, boilerplates, and sample tests.
+Creates a new folder for running SeleniumBase scripts.
+The new folder contains default config files,
+sample tests for helping new users get started, and
+Python boilerplates for setting up customized
+test frameworks.
 """
 
 import codecs
@@ -13,17 +16,30 @@ import os
 import sys
 
 
+def invalid_run_command():
+    exp = ("  ** mkdir **\n\n")
+    exp += "  Usage:\n"
+    exp += "          seleniumbase mkdir [DIRECTORY_NAME]\n"
+    exp += "  Example:\n"
+    exp += "          seleniumbase mkdir gui_tests\n"
+    exp += "  Output:\n"
+    exp += "          Creates a new folder for running SeleniumBase scripts.\n"
+    exp += "          The new folder contains default config files,\n"
+    exp += "          sample tests for helping new users get started, and\n"
+    exp += "          Python boilerplates for setting up customized\n"
+    exp += "          test frameworks.\n"
+    print("")
+    raise Exception('INVALID RUN COMMAND!\n\n%s' % exp)
+
+
 def main():
-    expected_arg = ("[DIRECTORY_NAME]")
     num_args = len(sys.argv)
     if sys.argv[0].split('/')[-1] == "seleniumbase" or (
             sys.argv[0].split('\\')[-1] == "seleniumbase"):
         if num_args < 3 or num_args > 3:
-            raise Exception('\n* INVALID RUN COMMAND! *  Usage:\n'
-                            '"seleniumbase mkdir %s"\n' % expected_arg)
+            invalid_run_command()
     else:
-        raise Exception('\n* INVALID RUN COMMAND! *  Usage:\n'
-                        '"seleniumbase mkdir %s"\n' % expected_arg)
+        invalid_run_command()
     dir_name = sys.argv[num_args-1]
     if len(str(dir_name)) < 2:
         raise Exception('Directory name length must be at least 2 '

--- a/console_scripts/sb_mkdir.py
+++ b/console_scripts/sb_mkdir.py
@@ -20,10 +20,10 @@ def main():
             sys.argv[0].split('\\')[-1] == "seleniumbase"):
         if num_args < 3 or num_args > 3:
             raise Exception('\n* INVALID RUN COMMAND! *  Usage:\n'
-                            '"seleniumbase convert %s"\n' % expected_arg)
+                            '"seleniumbase mkdir %s"\n' % expected_arg)
     else:
         raise Exception('\n* INVALID RUN COMMAND! *  Usage:\n'
-                        '"seleniumbase convert %s"\n' % expected_arg)
+                        '"seleniumbase mkdir %s"\n' % expected_arg)
     dir_name = sys.argv[num_args-1]
     if len(str(dir_name)) < 2:
         raise Exception('Directory name length must be at least 2 '

--- a/drivers/ReadMe.md
+++ b/drivers/ReadMe.md
@@ -1,0 +1,13 @@
+### SeleniumBase web driver storage
+
+* Usage:
+
+```bash
+seleniumbase install chromedriver
+seleniumbase install geckodriver
+seleniumbase install edgedriver
+```
+
+After running the commands above, web drivers will get downloaded into this folder. SeleniumBase will then use those drivers during test runs if present. (The drivers don't come with SeleniumBase by default.)
+
+If the necessary driver is not found in this location while running tests, SeleniumBase will instead look for the driver on the System PATH. If the necessary driver is not on the System PATH either, you'll get errors.

--- a/examples/ReadMe.md
+++ b/examples/ReadMe.md
@@ -1,22 +1,14 @@
 ## Running SeleniumBase Scripts
 
-(NOTE: If you didn't install SeleniumBase properly, these scripts won't work. Installation steps include ``pip install seleniumbase`` OR ``pip install -r requirements.txt`` + ``python setup.py develop``" from the top-level directory.)
+To run tests, make sure you've already installed SeleniumBase using ``pip install seleniumbase`` OR ``pip install -r requirements.txt`` + ``python setup.py develop`` from the top-level directory.
 
-To makes things easier, here's a simple GUI program that allows you to kick off a few example scripts by pressing a button:
+You can interchange **pytest** with **nosetests**, but using pytest is strongly recommended because developers stopped supporting nosetests. Chrome is the default browser if not specified.
 
-```bash
-python gui_test_runner.py
-```
+During test failures, logs and screenshots from the most recent test run will get saved to the ``latest_logs/`` folder. Those logs will get moved to ``archived_logs/`` if you have ARCHIVE_EXISTING_LOGS set to True in [settings.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py)
 
-(NOTE: With the exception of [my_first_test.py](https://github.com/seleniumbase/SeleniumBase/blob/master/examples/my_first_test.py), which should pass, many other tests in this folder fail on purpose to demonstrate features such as screenshots on failure, exception logging, and test reports.)
+(NOTE: Many tests in this folder fail on purpose to demonstrate the built-in logging, screenshots, and reporting features.)
 
-(NOTE: You can interchange ``pytest`` with ``nosetests`` in most of these examples.)
-
-<img src="https://cdn2.hubspot.net/hubfs/100006/images/The_GUI_Runner.png" title="GUI Test Runner" height="400">
-
-When you run tests, you’ll see two folders appear: “latest_logs” and “archived_logs”. The “latest_logs” folder will contain log files from the most recent test run, but logs will only be created if the test run is failing. Afterwards, logs from the “latest_logs” folder will get pushed to the “archived_logs” folder if you have have the ``ARCHIVE_EXISTING_LOGS`` feature enabled in [settings.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py).
-
-**For running scripts the usual way, here are some of the example run commands:**
+**Here are some example run commands to help get you started:**
 
 Run the example test in Chrome:
 ```bash
@@ -28,41 +20,51 @@ Run the example test in Firefox:
 pytest my_first_test.py --browser=firefox
 ```
 
-Run the example test in Demo Mode (runs slower and adds highlights):
+Run the example test in Demo Mode (highlights page objects being acted on):
 ```bash
 pytest my_first_test.py --browser=chrome --demo_mode
 ```
 
-Run the example test suite in Chrome and generate an html report: (nosetests-only)
+Run the example test suite and generate an pytest report: (pytest-only)
 ```bash
-nosetests my_test_suite.py --browser=chrome --report --show_report
+pytest basic_script.py --html=report.html
 ```
 
-Run the example test suite in Firefox and generate an html report: (nosetests-only)
+Run the example test suite and generate a nosetest report: (nosetests-only)
 ```bash
-nosetests my_test_suite.py --browser=firefox --report --show_report
+nosetests my_test_suite.py --report --show_report
 ```
 
-Run a test with configuration specifed by a config file:
+Run a test using a nosetest configuration file: (nosetests-only)
 ```bash
 nosetests my_first_test.py --config=example_config.cfg
 ```
 
-Run a test demonstrating the use of Python decorators available:
+Run a test demonstrating the use of SeleniumBase Python decorators available:
 ```bash
 pytest rate_limiting_test.py
 ```
 
-Run a failing test with pdb mode enabled: (If a test failure occurs, test enters pdb mode)
-```bash
-pytest test_fail.py --browser=chrome --pdb --pdb-failures
-```
-
-Run a failing test (and then look into the ``latest_logs`` folder afterwards:
+Run a failing test: (See the ``latest_logs/`` folder afterwards for logs and screenshots)
 ```bash
 pytest test_fail.py --browser=chrome
 ```
 
+Run a failing test with Debugging-mode enabled: (If a test failure occurs, pdb activates)
+```bash
+pytest test_fail.py --browser=chrome --pdb --pdb-failures -s
+```
+
 For more advanced run commands, such as using a proxy server,  see [../help_docs/customizing_test_runs.md](https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/customizing_test_runs.md)
+
+--------
+
+To makes things easier, here's a simple GUI program that allows you to kick off a few example scripts by pressing a button:
+
+```bash
+python gui_test_runner.py
+```
+
+<img src="https://cdn2.hubspot.net/hubfs/100006/images/The_GUI_Runner.png" title="GUI Test Runner" height="400">
 
 (NOTE: If you see any ``*.pyc`` files appear as you run tests, that's perfectly normal. Compiled bytecode is a natural result of running Python code.)

--- a/examples/my_first_test.py
+++ b/examples/my_first_test.py
@@ -9,11 +9,11 @@ class MyTestClass(BaseCase):
         self.click('a[rel="license"]')                  # Click element on page
         self.assert_text('free to copy', 'div center')    # Assert text on page
         self.open("http://xkcd.com/1481/")
-        title = self.get_attribute("#comic img", "title")   # Grab an attribute
+        title = self.get_attribute("#comic img", "title")    # Get an attribute
         self.assertTrue("86,400 seconds per day" in title)
-        self.click('link=Blag')                # Click link containing the text
+        self.click('link=Blag')                                 # Click on link
         self.assert_text('The blag of the webcomic', 'h2')
-        self.update_text('input#s', 'Robots!\n')  # Fill in field with the text
+        self.update_text('input#s', 'Robots!\n')                    # Type text
         self.assert_text('Hooray robots!', '#content')
         self.open('http://xkcd.com/1319/')
         self.assert_text('Automation', 'div#ctitle')

--- a/help_docs/customizing_test_runs.md
+++ b/help_docs/customizing_test_runs.md
@@ -1,20 +1,22 @@
-### Customizing test runs from the command line
+### Customizing test runs with **pytest** (or nosetests)
 
-In addition to [settings.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py), which allows you to customize the test framework, SeleniumBase gives you the flexibility to customize & control test runs from the command line:
+In addition to [settings.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py) (which lets you customize SeleniumBase global properties) you can customize test runs from the command line:
 
-* Set the browser for tests to use (Default: Chrome)
-* Change the automation speed (with Demo Mode)
+* Choose the browser for tests to use (Default: Chrome)
 * Choose betweeen pytest & nose unittest runners
-* Specify what to log and where to store logs
-* Choose additional variables to pass into tests
 * Choose whether to enter Debug Mode on failures
-* Specify a proxy server to connect to
-* Choose a database to save results to
+* Choose additional variables to pass into tests
+* Change the automation speed (with Demo Mode)
+* Choose whether to run tests multi-threaded
 * Choose a Selenium Grid to connect to
+* Choose a database to save results to
+* Choose a proxy server to connect to
 
 ...and more!
 
-**Examples:** (These are run from the **[examples](https://github.com/seleniumbase/SeleniumBase/tree/master/examples)** folder.):
+#### **Examples:**
+
+(These are run from the **[examples](https://github.com/seleniumbase/SeleniumBase/tree/master/examples)** folder.)
 
 ```bash
 pytest my_first_test.py
@@ -25,28 +27,29 @@ pytest my_first_test.py --browser=firefox
 
 pytest basic_script.py -s --pdb --pdb-failures
 
-pytest my_test_suite.py --server=IP_ADDRESS -n 4
-
 pytest basic_script.py --html=report.html
 
 nosetests my_test_suite.py --report --show_report
 
+pytest my_test_suite.py --server=IP_ADDRESS -n 4
+
 pytest my_test_suite.py --proxy=IP_ADDRESS:PORT
 ```
 
-You can interchange **nosetests** with **pytest**. Chrome is the default browser if not specified. The ``-s`` option may produce additional output to make debugging easier.
+You can interchange **pytest** with **nosetests**, but using pytest is strongly recommended because developers stopped supporting nosetests. Chrome is the default browser if not specified.
 
 (NOTE: If you're using **pytest** for running tests outside of the SeleniumBase repo, **you'll want a copy of [pytest.ini](https://github.com/seleniumbase/SeleniumBase/blob/master/pytest.ini) at the base of the new folder structure**. If using **nosetests**, the same applies for [setup.cfg](https://github.com/seleniumbase/SeleniumBase/blob/master/setup.cfg).)
 
-**Example tests using Logging**:
+#### **Example tests using Logging:**
+
 ```bash
 pytest my_test_suite.py --browser=chrome
 ```
-(NOTE: You'll automatically get full logging on test failures, which include screenshots, page source, and basic test info in the logs folder, which is ``latest_logs/`` initially, and those logs will be saved in ``archived_logs/`` if you have ARCHIVE_EXISTING_LOGS set to True in [settings.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py))
+(During test failures, logs and screenshots from the most recent test run will get saved to the ``latest_logs/`` folder. Those logs will get moved to ``archived_logs/`` if you have ARCHIVE_EXISTING_LOGS set to True in [settings.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py), otherwise log files with be cleaned up at the start of the next test run.)
 
-**Demo Mode:**
+#### **Demo Mode:**
 
-If any test is moving too fast for your eyes to see what's going on, you can run it in **Demo Mode** by adding ``--demo_mode`` on the command line, which pauses the browser briefly between actions, and highlights page elements being acted on:
+If any test is moving too fast for your eyes to see what's going on, you can run it in **Demo Mode** by adding ``--demo_mode`` on the command line, which pauses the browser briefly between actions, highlights page elements being acted on, and lets you know what test assertions are happening in real time:
 
 ```bash
 pytest my_first_test.py --browser=chrome --demo_mode
@@ -54,38 +57,34 @@ pytest my_first_test.py --browser=chrome --demo_mode
 
 You can override the default wait time by either updating [settings.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py) or by using ``--demo_sleep={NUM}`` when using Demo Mode. (NOTE: If you use ``--demo_sleep={NUM}`` without using ``--demo_mode``, nothing will happen.)
 
-If you ever make any changes to your local copy of ``settings.py``, you may need to run ``python setup.py install`` for those changes to take effect.
-
 ```bash
 pytest my_first_test.py --browser=chrome --demo_mode --demo_sleep=1.2
 ```
 
-**You can also use the following in your scripts to slow down the tests:**
+#### **Passing additional data to tests:**
+
+If you want to pass additional data from the command line to your tests, you can use ``--data=STRING``. Now inside your tests, you can use ``self.data`` to access that.
+
+#### **Running tests multithreaded:**
+
+To run Pytest multithreaded on multiple CPUs at the same time, add ``-n=NUM`` or ``-n NUM`` on the command line, where NUM is the number of CPUs you want to use.
+
+#### **Debugging tests:**
+
+**You can use the following code snippets in your scripts to help you debug issues:**
 ```python
 import time; time.sleep(5)  # sleep for 5 seconds (add this after the line you want to pause on)
 import ipdb; ipdb.set_trace()  # waits for your command. n = next line of current method, c = continue, s = step / next executed line (will jump)
+import pytest; pytest.set_trace()  # similar to ipdb, but specific to pytest
 ```
 
-(NOTE: If you're using pytest instead of nosetests and you want to use ipdb in your script for debugging purposes, you'll either need to add ``--capture=no`` on the command line, or use ``import pytest; pytest.set_trace()`` instead of using ipdb. More info on that [here](http://stackoverflow.com/questions/2678792/can-i-debug-with-python-debugger-when-using-py-test-somehow).)
-
-You may also want to have your test sleep in other situations where you need to have your test wait for something. If you know what you're waiting for, you should be specific by using a command that waits for something specific to happen.
-
-**If you need to debug things on the fly (in case of errors), use this:**
+**To pause an active test that throws an exception or error, add ``--pdb --pdb-failures -s``:**
 
 ```bash
 pytest my_first_test.py --browser=chrome --pdb --pdb-failures -s
 ```
 
-The above code (with --pdb) will leave your browser window open in case there's a failure, which is possible if the web pages from the example change the data that's displayed on the page. (ipdb commands: 'c', 's', 'n' => continue, step, next). You may need the ``-s`` in order to see all console output.
-
-**Here are some other useful nosetest arguments for appending to your run commands:**
-
-```bash
---logging-level=INFO  # Hide DEBUG messages, which can be overwhelming.
--x  # Stop running the tests after the first failure is reached.
--v  # Prints the full test name rather than a dot for each test.
---with-id  # If -v is also used, will number the tests for easy counting.
-```
+The code above will leave your browser window open in case there's a failure. (ipdb commands: 'c', 's', 'n' => continue, step, next).
 
 #### **Pytest Reports:**
 
@@ -106,6 +105,15 @@ nosetests my_test_suite.py --report
 ![](http://cdn2.hubspot.net/hubfs/100006/images/Test_Report_2.png "Example Nosetest Report")
 
 (NOTE: You can add ``--show_report`` to immediately display Nosetest reports after the test suite completes. Only use ``--show_report`` when running tests locally because it pauses the test run.)
+
+Here are some other useful **nosetest**-specific arguments:
+
+```bash
+--logging-level=INFO  # Hide DEBUG messages, which can be overwhelming.
+-x  # Stop running the tests after the first failure is reached.
+-v  # Prints the full test name rather than a dot for each test.
+--with-id  # If -v is also used, will number the tests for easy counting.
+```
 
 #### **Using a Proxy Server:**
 

--- a/help_docs/webdriver_installation.md
+++ b/help_docs/webdriver_installation.md
@@ -1,7 +1,17 @@
-## Installing Google Chromedriver, Firefox Geckodriver, and other drivers
+## Installing Google Chromedriver, Firefox Geckodriver, and Microsoft Edge Driver
 
 
-To run automation on various web browsers, you'll need to download a driver file for each one and place it on your System **[PATH](http://java.com/en/download/help/path.xml)**. On a Mac, ``/usr/local/bin`` is a good spot. On Windows, make sure you set the System Path under Environment Variables to include the location where you placed the driver files. You may want to download newer versions of drivers as they become available.
+To run web automation, you'll need to download a web driver for each browser you plan on using and place those on your System **[PATH](http://java.com/en/download/help/path.xml)**. Additionaly, you can place drivers in the [SeleniumBase `drivers` folder](https://github.com/seleniumbase/SeleniumBase/blob/master/drivers). If you plan on taking the latter option, here are some commands that'll automatically download the driver you need into the ``drivers`` folder once you've installed SeleniumBase:
+
+```bash
+seleniumbase install chromedriver
+seleniumbase install geckodriver
+seleniumbase install edgedriver
+```
+
+If you plan on using the [Selenium Grid integration](https://github.com/seleniumbase/SeleniumBase/blob/master/integrations/selenium_grid/ReadMe.md) (which allows for remote webdriver), you'll need to put the drivers on your System PATH. On a Mac and Linux, ``/usr/local/bin`` is a good PATH spot. On Windows, you may need to set the System PATH under Environment Variables to include the location where you placed the driver files. As a shortcut, you could place the driver files into your Python ``Scripts/`` folder in the location where you have Python installed, which should already be on your System PATH.
+
+Here's where you can go to manually install web drivers from the source:
 
 * For Chrome, get [Chromedriver](https://sites.google.com/a/chromium.org/chromedriver/downloads) on your System PATH.
 
@@ -13,11 +23,9 @@ To run automation on various web browsers, you'll need to download a driver file
 
 * For PhantomJS headless browser automation, get [PhantomJS](http://phantomjs.org/download.html) on your System PATH. (NOTE: <i>PhantomJS is no longer officially supported by SeleniumHQ</i>)
 
-(NOTE: <i>If you can't get a WebDriver on your system PATH, you'll need to edit ``requirements.txt`` and ``setup.py`` to use selenium==2.53.6 instead of selenium 3.x, which will limit you to running tests on [Firefox 46.x](https://ftp.mozilla.org/pub/firefox/releases/46.0.1/) & earlier.</i>)
-
 **Mac**:
 
-* On a Mac, you can install drivers more easily by using ``brew`` (aka ``homebrew``), but you have to install that first. [Brew installation instructions are here](https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/install_python_pip_git.md).
+* On a Mac, you can also install drivers by using ``brew`` (aka ``homebrew``), but you'll need to install that first. [Brew installation instructions are here](https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/install_python_pip_git.md).
 
 ```bash
 brew cask install chromedriver
@@ -25,7 +33,7 @@ brew cask install chromedriver
 brew install geckodriver
 ```
 
-(NOTE: If your existing version of chromedriver is less than 2.37, **upgrading is required!**)
+(NOTE: If your existing version of chromedriver is less than 2.41, **upgrading is required** in order to keep up with the latest version of Chrome!)
 
 ```bash
 brew cask upgrade chromedriver
@@ -35,18 +43,20 @@ brew upgrade geckodriver
 
 **Linux**:
 
+If you still need the web drivers, here are some scripts to help you install chromedriver and geckodriver on a Linux machine:
+
 ```bash
-wget http://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip
+wget http://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
 unzip chromedriver_linux64.zip
 mv chromedriver /usr/local/bin/
 chmod +x /usr/local/bin/chromedriver
 ```
 
 ```bash
-wget https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-linux64.tar.gz
-tar xvfz geckodriver-v0.20.0-linux64.tar.gz
+wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz
+tar xvfz geckodriver-v0.21.0-linux64.tar.gz
 mv geckodriver /usr/local/bin/
 chmod +x /usr/local/bin/geckodriver
 ```
 
-* To verify that the web drivers are working, **[follow these instructions](https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/verify_webdriver.md)**.
+* If you wish to verify that web drivers are working, **[follow these instructions](https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/verify_webdriver.md)**.

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2816,10 +2816,15 @@ class BaseCase(unittest.TestCase):
                 self.testcase_manager.insert_testcase_data(data_payload)
                 self.case_start_time = int(time.time() * 1000)
             if self.headless:
-                from pyvirtualdisplay import Display
-                self.display = Display(visible=0, size=(1920, 1200))
-                self.display.start()
-                self.headless_active = True
+                try:
+                    from pyvirtualdisplay import Display
+                    self.display = Display(visible=0, size=(1920, 1200))
+                    self.display.start()
+                    self.headless_active = True
+                except Exception:
+                    # pyvirtualdisplay might not be necessary anymore because
+                    # Chrome and Firefox now have built-in headless displays
+                    pass
 
         # Launch WebDriver for both Pytest and Nosetests
         if not hasattr(self, "browser"):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages  # noqa
 
 setup(
     name='seleniumbase',
-    version='1.12.3',
+    version='1.13.0',
     description='Web Automation & Testing Framework - http://seleniumbase.com',
     long_description='Web Automation and Testing Framework - seleniumbase.com',
     platforms='Mac * Windows * Linux * Docker',

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
               'seleniumbase.masterqa',
               'seleniumbase.plugins',
               'console_scripts',
+              'drivers',
               'integrations',
               'integrations.selenium_grid',
               'integrations.selenium_ide',


### PR DESCRIPTION
* You can now install web drivers by using seleniumbase console scripts:
```
seleniumbase install chromedriver
seleniumbase install geckodriver
seleniumbase install edgedriver
```
(SeleniumBase takes care of determining the latest version for your operating system's platform, downloading the zip file, extracting the driver from the zip file to the SeleniumBase ``drivers/`` folder, and setting the permissions of the driver with "chmod" to make it executable for browser tests.)

* You can now run tests in headless mode without using pyvirtualdisplay.
Usage:  ``--headless``. (Make sure you have the latest versions of Chrome and Firefox installed.)
```
pytest my_first_test.py --browser=chrome --headless
```