### PR TITLE
Python 3.7.0 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ requests==2.19.1
 beautifulsoup4==4.6.0
 unittest2==1.1.0
 chardet==3.0.4
+urllib3==1.23
 boto==2.48.0
 ipdb==0.11
 parameterized==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools
 ipython==5.6.0
 selenium==3.14.0
 nose==1.3.7
-pytest==3.7.3
+pytest==3.7.4
 pytest-html==1.19.0
 pytest-xdist==1.23.0
 six==1.11.0

--- a/seleniumbase/common/encryption.py
+++ b/seleniumbase/common/encryption.py
@@ -45,8 +45,8 @@ def reverse_shuffle_string(string):
         return string
     new_string = ""
     odd = (len(string) % 2 == 1)
-    part1 = string[:int(len(string)/2):1]
-    part2 = string[int(len(string)/2)::1]
+    part1 = string[:int(len(string) / 2):1]
+    part2 = string[int(len(string) / 2)::1]
     for c in range(len(part1)):
         new_string += part2[c]
         new_string += part1[c]
@@ -118,18 +118,18 @@ def decrypt(string):
             rem4 = (len(string) + ord_string_sum(string)) % 2
         if len(string) % 2 != 0:
             if rem3 == 1:
-                string = (chr(ord(string[-1])-5-rem1) + string +
-                          chr(ord(string[-1])-13-rem1))
+                string = (chr(ord(string[-1]) - 5 - rem1) + string +
+                          chr(ord(string[-1]) - 13 - rem1))
             else:
-                string = (chr(ord(string[-1])-11-rem1) + string +
-                          chr(ord(string[-1])-23-rem1))
+                string = (chr(ord(string[-1]) - 11 - rem1) + string +
+                          chr(ord(string[-1]) - 23 - rem1))
         elif len(string) > 1:
             if rem4 == 1:
-                string = (chr(ord(string[0])-19+rem2) + string +
-                          chr(ord(string[0])-7-rem2))
+                string = (chr(ord(string[0]) - 19 + rem2) + string +
+                          chr(ord(string[0]) - 7 - rem2))
             else:
-                string = (chr(ord(string[0])-26+rem2) + string +
-                          chr(ord(string[0])-12-rem2))
+                string = (chr(ord(string[0]) - 26 + rem2) + string +
+                          chr(ord(string[0]) - 12 - rem2))
         rem5 = (len(string) + ord_string_sum(string)) % 23
         string = rotate(string, rem5)
         result = str_xor(shuffle_string(string)[::-1], xor_key)

--- a/seleniumbase/console_scripts/sb_install.py
+++ b/seleniumbase/console_scripts/sb_install.py
@@ -62,7 +62,7 @@ def main():
             invalid_run_command()
     else:
         invalid_run_command()
-    name = sys.argv[num_args-1]
+    name = sys.argv[num_args - 1]
 
     file_name = None
     download_url = None

--- a/seleniumbase/console_scripts/sb_install.py
+++ b/seleniumbase/console_scripts/sb_install.py
@@ -19,12 +19,10 @@ import requests
 import shutil
 import sys
 import tarfile
+import urllib3
 import zipfile
 from seleniumbase import drivers  # webdriver storage folder for SeleniumBase
-if sys.version_info[0] == 2:
-    from urllib import urlopen
-else:
-    from urllib.request import urlopen
+urllib3.disable_warnings()
 DRIVER_DIR = os.path.dirname(os.path.realpath(drivers.__file__))
 
 
@@ -190,7 +188,8 @@ def main():
     if not os.path.exists(downloads_folder):
         os.mkdir(downloads_folder)
     local_file = open(file_path, 'wb')
-    remote_file = urlopen(download_url)
+    http = urllib3.PoolManager()
+    remote_file = http.request('GET', download_url, preload_content=False)
     print('\nDownloading %s from:\n%s ...' % (file_name, download_url))
     local_file.write(remote_file.read())
     local_file.close()

--- a/seleniumbase/console_scripts/sb_mkdir.py
+++ b/seleniumbase/console_scripts/sb_mkdir.py
@@ -40,7 +40,7 @@ def main():
             invalid_run_command()
     else:
         invalid_run_command()
-    dir_name = sys.argv[num_args-1]
+    dir_name = sys.argv[num_args - 1]
     if len(str(dir_name)) < 2:
         raise Exception('Directory name length must be at least 2 '
                         'characters long!')

--- a/seleniumbase/core/style_sheet.py
+++ b/seleniumbase/core/style_sheet.py
@@ -2,8 +2,8 @@ title = '''<meta id="OGTitle" property="og:title" content="SeleniumBase">
         <title>Test Report</title>
         <link rel="SHORTCUT ICON"
         href="%s" /> ''' % (
-            "https://raw.githubusercontent.com/seleniumbase/SeleniumBase"
-            "/master/seleniumbase/resources/favicon.ico")
+        "https://raw.githubusercontent.com/seleniumbase/SeleniumBase"
+        "/master/seleniumbase/resources/favicon.ico")
 
 style = title + '''<style type="text/css">
         html {

--- a/seleniumbase/core/testcase_manager.py
+++ b/seleniumbase/core/testcase_manager.py
@@ -84,7 +84,7 @@ class ExecutionQueryPayload:
             "total_execution_time": self.total_execution_time,
             "username": self.username,
             "guid": self.guid
-            }
+        }
 
 
 class TestcaseDataPayload:

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -755,7 +755,9 @@ class BaseCase(unittest.TestCase):
             '''s.type = "text/css";'''
             '''s.appendChild(document.createTextNode("%s"));'''
             '''h.appendChild(s);''')
-        self.execute_script(add_css_style_script % re.escape(css_style))
+        css_style = re.escape(css_style)
+        css_style = self.__escape_quotes_if_needed(css_style)
+        self.execute_script(add_css_style_script % css_style)
 
     def add_js_code_from_link(self, js_link):
         if js_link.startswith("//"):
@@ -768,7 +770,9 @@ class BaseCase(unittest.TestCase):
             '''s.onload = function() { null };'''
             '''s.appendChild(document.createTextNode("%s"));'''
             '''h.appendChild(s);''')
-        self.execute_script(add_js_code_script % re.escape(js_code))
+        js_code = re.escape(js_code)
+        js_code = self.__escape_quotes_if_needed(js_code)
+        self.execute_script(add_js_code_script % js_code)
 
     def add_meta_tag(self, http_equiv=None, content=None):
         if http_equiv is None:
@@ -811,6 +815,12 @@ class BaseCase(unittest.TestCase):
             '''Unable to load jQuery on "%s" due to a possible violation '''
             '''of the website's Content Security Policy '''
             '''directive. ''' % self.driver.current_url)
+
+    def __are_quotes_escaped(self, string):
+        return page_utils.are_quotes_escaped(string)
+
+    def __escape_quotes_if_needed(self, string):
+        return page_utils.escape_quotes_if_needed(string)
 
     def __activate_bootstrap(self):
         """ Allows you to use Bootstrap Tours with SeleniumBase
@@ -995,6 +1005,7 @@ class BaseCase(unittest.TestCase):
         if not selector:
             selector = "html"
         selector = re.escape(selector)
+        selector = self.__escape_quotes_if_needed(selector)
 
         if not name:
             name = "default"
@@ -1005,9 +1016,11 @@ class BaseCase(unittest.TestCase):
         if not title:
             title = ""
         title = re.escape(title)
+        title = self.__escape_quotes_if_needed(title)
 
         if message:
             message = re.escape(message)
+            message = self.__escape_quotes_if_needed(message)
         else:
             message = ""
 
@@ -1324,6 +1337,7 @@ class BaseCase(unittest.TestCase):
         for x in range(int(timeout * 10)):
             try:
                 selector = re.escape(selector)
+                selector = self.__escape_quotes_if_needed(selector)
                 element = self.execute_script(
                     """return document.querySelector('%s')""" % selector)
                 if element:
@@ -1439,9 +1453,11 @@ class BaseCase(unittest.TestCase):
                 duration = settings.DEFAULT_MESSAGE_DURATION
             else:
                 duration = self.message_duration
+        message = re.escape(message)
+        message = self.__escape_quotes_if_needed(message)
         messenger_script = ('''Messenger().post({message: "%s", type: "%s", '''
                             '''hideAfter: %s, hideOnNavigate: true});'''
-                            % (re.escape(message), style, duration))
+                            % (message, style, duration))
         try:
             self.execute_script(messenger_script)
         except Exception:
@@ -1481,6 +1497,7 @@ class BaseCase(unittest.TestCase):
                 "Exception: Could not convert {%s}(by=%s) to CSS_SELECTOR!" % (
                     selector, by))
         selector = re.escape(selector)
+        selector = self.__escape_quotes_if_needed(selector)
         script = ("""var $elm = document.querySelector('%s');
                   $val = window.getComputedStyle($elm).getPropertyValue('%s');
                   return $val;"""
@@ -1505,6 +1522,7 @@ class BaseCase(unittest.TestCase):
             # Don't run action if can't convert to CSS_Selector for JavaScript
             return
         selector = re.escape(selector)
+        selector = self.__escape_quotes_if_needed(selector)
         script = ("""document.querySelector('%s').style.zIndex = '9999';"""
                   % selector)
         self.execute_script(script)
@@ -1560,10 +1578,12 @@ class BaseCase(unittest.TestCase):
 
         if ":contains" not in selector and ":first" not in selector:
             selector = re.escape(selector)
+            selector = self.__escape_quotes_if_needed(selector)
             self.__highlight_with_js(selector, loops, o_bs)
         else:
             selector = self.__make_css_match_first_element_only(selector)
             selector = re.escape(selector)
+            selector = self.__escape_quotes_if_needed(selector)
             try:
                 self.__highlight_with_jquery(selector, loops, o_bs)
             except Exception:
@@ -1703,6 +1723,7 @@ class BaseCase(unittest.TestCase):
                 self.__scroll_to_element(element)
         css_selector = self.convert_to_css_selector(selector, by=by)
         css_selector = re.escape(css_selector)
+        css_selector = self.__escape_quotes_if_needed(css_selector)
         self.__js_click(selector, by=by)  # The real "magic" happens here
         self.__demo_mode_pause_if_active()
 
@@ -1768,6 +1789,7 @@ class BaseCase(unittest.TestCase):
         from seleniumbase.config import ad_block_list
         for css_selector in ad_block_list.AD_BLOCK_LIST:
             css_selector = re.escape(css_selector)
+            css_selector = self.__escape_quotes_if_needed(css_selector)
             script = ("""var $elements = document.querySelectorAll('%s');
                       var index = 0, length = $elements.length;
                       for(; index < length; index++){
@@ -1879,7 +1901,9 @@ class BaseCase(unittest.TestCase):
         if not self.demo_mode:
             self.scroll_to(orginal_selector, by=by, timeout=timeout)
         value = re.escape(new_value)
+        value = self.__escape_quotes_if_needed(value)
         css_selector = re.escape(css_selector)
+        css_selector = self.__escape_quotes_if_needed(css_selector)
         script = ("""document.querySelector('%s').value='%s';"""
                   % (css_selector, value))
         self.execute_script(script)
@@ -1915,8 +1939,11 @@ class BaseCase(unittest.TestCase):
         self.scroll_to(selector, by=by)
         selector = self.convert_to_css_selector(selector, by=by)
         selector = self.__make_css_match_first_element_only(selector)
+        selector = self.__escape_quotes_if_needed(selector)
+        new_value = re.escape(new_value)
+        new_value = self.__escape_quotes_if_needed(new_value)
         update_text_script = """jQuery('%s').val('%s')""" % (
-            selector, re.escape(new_value))
+            selector, new_value)
         self.safe_execute_script(update_text_script)
         if new_value.endswith('\n'):
             element.send_keys('\n')
@@ -1967,8 +1994,8 @@ class BaseCase(unittest.TestCase):
         self.scroll_to(hover_selector, by=hover_by)
         pre_action_url = self.driver.current_url
         element = page_actions.hover_and_click(
-                self.driver, hover_selector, click_selector,
-                hover_by, click_by, timeout)
+            self.driver, hover_selector, click_selector,
+            hover_by, click_by, timeout)
         if self.demo_mode:
             if self.driver.current_url != pre_action_url:
                 self.__demo_mode_pause_if_active()
@@ -2557,8 +2584,8 @@ class BaseCase(unittest.TestCase):
         current_url = self.driver.current_url
         message = self.__get_exception_message()
         self.__page_check_failures.append(
-                "CHECK #%s: (%s)\n %s" % (
-                    self.__page_check_count, current_url, message))
+            "CHECK #%s: (%s)\n %s" % (
+                self.__page_check_count, current_url, message))
 
     def delayed_assert_element(self, selector, by=By.CSS_SELECTOR,
                                timeout=settings.MINI_TIMEOUT):
@@ -2650,6 +2677,7 @@ class BaseCase(unittest.TestCase):
         selector, by = self.__recalculate_selector(selector, by)
         css_selector = self.convert_to_css_selector(selector, by=by)
         css_selector = re.escape(css_selector)
+        css_selector = self.__escape_quotes_if_needed(css_selector)
         script = ("""var simulateClick = function (elem) {
                          var evt = new MouseEvent('click', {
                              bubbles: true,
@@ -2775,7 +2803,7 @@ class BaseCase(unittest.TestCase):
             if not tiny:
                 time.sleep(wait_time)
             else:
-                time.sleep(wait_time/3.4)
+                time.sleep(wait_time / 3.4)
 
     def __demo_mode_scroll_if_active(self, selector, by):
         if self.demo_mode:
@@ -2876,10 +2904,12 @@ class BaseCase(unittest.TestCase):
 
         if ":contains" not in selector and ":first" not in selector:
             selector = re.escape(selector)
+            selector = self.__escape_quotes_if_needed(selector)
             self.__highlight_with_js_2(message, selector, o_bs)
         else:
             selector = self.__make_css_match_first_element_only(selector)
             selector = re.escape(selector)
+            selector = self.__escape_quotes_if_needed(selector)
             try:
                 self.__highlight_with_jquery_2(message, selector, o_bs)
             except Exception:

--- a/seleniumbase/fixtures/page_utils.py
+++ b/seleniumbase/fixtures/page_utils.py
@@ -83,6 +83,37 @@ def _save_data_as(data, destination_folder, file_name):
     out_file.close()
 
 
+def are_quotes_escaped(string):
+    if (string.count("\\'") != string.count("'") or
+            string.count('\\"') != string.count('"')):
+        return True
+    return False
+
+
+def escape_quotes_if_needed(string):
+    """
+    re.escape() works differently in Python 3.7.0 than earlier versions:
+
+    Python 3.6.5:
+    >>> import re
+    >>> re.escape('"')
+    '\\"'
+
+    Python 3.7.0:
+    >>> import re
+    >>> re.escape('"')
+    '"'
+
+    SeleniumBase needs quotes to be properly escaped for Javascript calls.
+    """
+    if are_quotes_escaped(string):
+        if string.count("'") != string.count("\\'"):
+            string = string.replace("'", "\\'")
+        if string.count('"') != string.count('\\"'):
+            string = string.replace('"', '\\"')
+    return string
+
+
 def _jq_format(code):
     """
     DEPRECATED - Use re.escape() instead, which performs the intended action.

--- a/seleniumbase/fixtures/xpath_to_css.py
+++ b/seleniumbase/fixtures/xpath_to_css.py
@@ -70,7 +70,7 @@ def _filter_xpath_grouping(xpath):
     index = xpath.rfind(')')
     if index == -1:
         raise XpathException("Invalid or unsupported Xpath: %s" % xpath)
-    xpath = xpath[:index] + xpath[index+1:]
+    xpath = xpath[:index] + xpath[index + 1:]
     return xpath
 
 

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -23,12 +23,13 @@ def pytest_addoption(parser):
     parser.addoption('--env', action='store',
                      dest='environment',
                      choices=(
-                        constants.Environment.QA,
-                        constants.Environment.STAGING,
-                        constants.Environment.PRODUCTION,
-                        constants.Environment.MASTER,
-                        constants.Environment.LOCAL,
-                        constants.Environment.TEST),
+                         constants.Environment.QA,
+                         constants.Environment.STAGING,
+                         constants.Environment.PRODUCTION,
+                         constants.Environment.MASTER,
+                         constants.Environment.LOCAL,
+                         constants.Environment.TEST
+                     ),
                      default=constants.Environment.TEST,
                      help="The environment to run the tests in.")
     parser.addoption('--data', dest='data',
@@ -48,7 +49,8 @@ def pytest_addoption(parser):
     parser.addoption('--database_env', action='store',
                      dest='database_env',
                      choices=(
-                        'prod', 'qa', 'staging', 'test', 'local', 'master'),
+                         'prod', 'qa', 'staging', 'test', 'local', 'master'
+                     ),
                      default='test',
                      help=optparse.SUPPRESS_HELP)
     parser.addoption('--with-s3_logging', action="store_true",

--- a/seleniumbase/utilities/selenium_ide/convert_ide.py
+++ b/seleniumbase/utilities/selenium_ide/convert_ide.py
@@ -17,6 +17,7 @@ Output:
 import codecs
 import re
 import sys
+from seleniumbase.fixtures import page_utils
 
 
 def main():
@@ -581,14 +582,16 @@ def main():
         if data:
             # quote_type = data.group(1)
             selector = data.group(2)
+            selector = re.escape(selector)
+            selector = page_utils.escape_quotes_if_needed(selector)
             if int(line_num) < num_lines - 1:
                 regex_string = (r'''^\s*self.click\(["|']'''
-                                + re.escape(selector) + r'''["|']\)\s*$''')
+                                + selector + r'''["|']\)\s*$''')
                 data2 = re.match(regex_string, lines[line_num+1])
                 if data2:
                     continue
                 regex_string = (r'''^\s*self.update_text\(["|']'''
-                                + re.escape(selector)
+                                + selector
                                 + r'''["|'], [\S\s]+\)\s*$''')
                 data2 = re.match(regex_string, lines[line_num+1])
                 if data2:
@@ -606,9 +609,11 @@ def main():
         if data:
             # quote_type = data.group(1)
             link_text = data.group(2)
+            link_text = re.escape(link_text)
+            link_text = page_utils.escape_quotes_if_needed(link_text)
             if int(line_num) < num_lines - 2:
                 regex_string = (r'''^\s*self.click\(["|']link='''
-                                + re.escape(link_text) + r'''["|']\)\s*$''')
+                                + link_text + r'''["|']\)\s*$''')
                 data2 = re.match(regex_string, lines[line_num+1])
                 if data2:
                     continue

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'beautifulsoup4==4.6.0',
         'unittest2==1.1.0',
         'chardet==3.0.4',
+        'urllib3==1.23',
         'boto==2.48.0',
         'ipdb==0.11',
         'parameterized==0.6.1',

--- a/setup.py
+++ b/setup.py
@@ -63,20 +63,21 @@ setup(
         'ipdb==0.11',
         'parameterized==0.6.1',
         'PyVirtualDisplay==0.2.1',
-        ],
-    packages=['seleniumbase',
-              'seleniumbase.common',
-              'seleniumbase.config',
-              'seleniumbase.console_scripts',
-              'seleniumbase.core',
-              'seleniumbase.drivers',
-              'seleniumbase.fixtures',
-              'seleniumbase.masterqa',
-              'seleniumbase.plugins',
-              'seleniumbase.utilities',
-              'seleniumbase.utilities.selenium_grid',
-              'seleniumbase.utilities.selenium_ide',
-              ],
+    ],
+    packages=[
+        'seleniumbase',
+        'seleniumbase.common',
+        'seleniumbase.config',
+        'seleniumbase.console_scripts',
+        'seleniumbase.core',
+        'seleniumbase.drivers',
+        'seleniumbase.fixtures',
+        'seleniumbase.masterqa',
+        'seleniumbase.plugins',
+        'seleniumbase.utilities',
+        'seleniumbase.utilities.selenium_grid',
+        'seleniumbase.utilities.selenium_ide',
+    ],
     entry_points={
         'console_scripts': [
             'seleniumbase = seleniumbase.console_scripts.run:main',
@@ -90,10 +91,10 @@ setup(
             ('db_reporting = '
              'seleniumbase.plugins.db_reporting_plugin:DBReporting'),
             's3_logging = seleniumbase.plugins.s3_logging_plugin:S3Logging',
-            ],
+        ],
         'pytest11': ['seleniumbase = seleniumbase.plugins.pytest_plugin']
-        }
-    )
+    }
+)
 
 # print(os.system("cat seleniumbase.egg-info/PKG-INFO"))
 print("\n*** SeleniumBase Installation Complete! ***\n")

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'ipython==5.6.0',
         'selenium==3.14.0',
         'nose==1.3.7',
-        'pytest==3.7.3',
+        'pytest==3.7.4',
         'pytest-html==1.19.0',
         'pytest-xdist==1.23.0',
         'six==1.11.0',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.15.4',
+    version='1.15.5',
     description='All-In-One Test Automation Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fixing bugs that were seen when switching to Python 3.7.0

After some investigation, I learned that the functionality of Python's re.escape() has changed between Python 3.6.5 and Python 3.7.0:

Python 3.6.5:
```python
>>> import re
>>> re.escape('"')
'\\"'
```

Python 3.7.0:
```python
>>> import re
>>> re.escape('"')
'"'
```

Also fixing an unrelated bug with Geckodriver automatic downloads. To do this, I switched to using urllib3.