### PR TITLE
Fix building image from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,6 @@ RUN exec "$@"
 #=====================
 COPY seleniumbase /SeleniumBase/seleniumbase/
 COPY examples /SeleniumBase/examples/
-COPY console_scripts /SeleniumBase/console_scripts/
 COPY integrations /SeleniumBase/integrations/
 COPY requirements.txt /SeleniumBase/requirements.txt
 COPY setup.py /SeleniumBase/setup.py


### PR DESCRIPTION
Hello ✋ 
Because of this change https://github.com/seleniumbase/SeleniumBase/commit/6f79b0857d6f1dec1a933dfbb3329f99c8bbfaae, we cannot build Docker image from Dockerfile.

logs
```
...
Step 9/29 : RUN echo "Starting X virtual framebuffer (Xvfb) in background..."
 ---> Using cache
 ---> 277270a55a19
Step 10/29 : RUN Xvfb -ac :99 -screen 0 1280x1024x16 > /dev/null 2>&1 &
 ---> Using cache
 ---> 7634243c9614
Step 11/29 : RUN export DISPLAY=:99
 ---> Using cache
 ---> e64532c242e9
Step 12/29 : RUN exec "$@"
 ---> Using cache
 ---> e076e3ef48f8
Step 13/29 : COPY seleniumbase /SeleniumBase/seleniumbase/
 ---> 31cf11d7613e
Step 14/29 : COPY examples /SeleniumBase/examples/
 ---> 6f48421c2a15
Step 15/29 : COPY console_scripts /SeleniumBase/console_scripts/
COPY failed: stat /var/lib/docker/tmp/docker-builder945105106/console_scripts: no such file or directory
```
