### PR TITLE
Sync "requests" and "urllib3" dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ ipdb
 chardet
 unittest2
 selenium==3.14.1
-requests>=2.20.0
+requests==2.20.0
+urllib3==1.24
 pytest>=3.9.1
 pytest-cov>=2.6.0
 pytest-html>=1.19.0

--- a/seleniumbase/console_scripts/sb_install.py
+++ b/seleniumbase/console_scripts/sb_install.py
@@ -16,12 +16,13 @@ Output:
 import os
 import platform
 import requests
+import urllib3  # Some systems don't have requests.packages.urllib3
 import shutil
 import sys
 import tarfile
 import zipfile
 from seleniumbase import drivers  # webdriver storage folder for SeleniumBase
-requests.packages.urllib3.disable_warnings()
+urllib3.disable_warnings()
 DRIVER_DIR = os.path.dirname(os.path.realpath(drivers.__file__))
 
 
@@ -185,7 +186,7 @@ def main():
     if not os.path.exists(downloads_folder):
         os.mkdir(downloads_folder)
     local_file = open(file_path, 'wb')
-    http = requests.packages.urllib3.PoolManager()
+    http = urllib3.PoolManager()
     remote_file = http.request('GET', download_url, preload_content=False)
     print('\nDownloading %s from:\n%s ...' % (file_name, download_url))
     local_file.write(remote_file.read())

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ setup(
         'chardet',
         'unittest2',
         'selenium==3.14.1',
-        'requests>=2.20.0',
+        'requests==2.20.0',  # Changing this may effect "urllib3"
+        'urllib3==1.24',  # Keep this lib in sync with "requests"
         'pytest>=3.9.1',
         'pytest-cov>=2.6.0',
         'pytest-html>=1.19.0',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.16.10',
+    version='1.16.11',
     description='All-In-One Test Automation Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Sync "requests" and "urllib3" dependencies

Based on compatibility issues between python "requests" and "urllib3" (See https://github.com/requests/requests/issues/4830 ) I'm locking down the versions used in seleniumbase to keep them in sync and prevent dependency conflicts. I'll check frequently on newer versions of those libs to see if I can safely update the version used in seleniumbase.