### PR TITLE
Fix issue with proxy server auth in chrome headless mode

### DIFF
--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -395,7 +395,13 @@ def get_local_driver(
                 downloads_path, proxy_string, proxy_auth,
                 proxy_user, proxy_pass)
             if headless:
-                chrome_options.add_argument("--headless")
+                # Headless Chrome doesn't support extensions, which are
+                # required when using a proxy server that has authentication.
+                # Instead, base_case.py will use PyVirtualDisplay when not
+                # using Chrome's built-in headless mode. See link for details:
+                # https://bugs.chromium.org/p/chromium/issues/detail?id=706008
+                if not proxy_auth:
+                    chrome_options.add_argument("--headless")
                 chrome_options.add_argument("--disable-gpu")
                 chrome_options.add_argument("--no-sandbox")
             if LOCAL_CHROMEDRIVER and os.path.exists(LOCAL_CHROMEDRIVER):

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2234,7 +2234,7 @@ class BaseCase(unittest.TestCase):
             if self.headless:
                 # Make sure the invisible browser window is big enough
                 try:
-                    self.set_window_size(1920, 1200)
+                    self.set_window_size(1440, 1080)
                     self.wait_for_ready_state_complete()
                 except Exception:
                     # This shouldn't fail, but in case it does,
@@ -2247,7 +2247,7 @@ class BaseCase(unittest.TestCase):
                         if settings.START_CHROME_IN_FULL_SCREEN_MODE:
                             self.driver.maximize_window()
                         else:
-                            self.driver.set_window_size(1250, 800)
+                            self.driver.set_window_size(1250, 840)
                         self.wait_for_ready_state_complete()
                     except Exception:
                         pass  # Keep existing browser resolution
@@ -2654,7 +2654,7 @@ class BaseCase(unittest.TestCase):
             if self.headless:
                 try:
                     from pyvirtualdisplay import Display
-                    self.display = Display(visible=0, size=(1920, 1200))
+                    self.display = Display(visible=0, size=(1440, 1080))
                     self.display.start()
                     self.headless_active = True
                 except Exception:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.16.16',
+    version='1.16.17',
     description='All-In-One Test Automation Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fix issue with proxy server auth in chrome headless mode.

When using a proxy server that has authentication with Chrome in headless mode, SeleniumBase will now use PyVirtualDisplay (already implemented in https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/fixtures/base_case.py) rather than using Chrome's built-in headless mode because Chrome doesn't allow extensions when using headless mode. This assumes that the user's system already supports Xvfb (the headless display system) in order to run with PyVirtualDisplay.

See https://bugs.chromium.org/p/chromium/issues/detail?id=706008 , where a member from the Chromium team says: "Headless mode doesn't currently support extensions".