### PR TITLE
Fix edge case with BaseCase tearDown() method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ unittest2
 selenium==3.141.0
 requests==2.20.0
 urllib3==1.24.1
-pytest>=3.10.0
+pytest>=4.0.0
 pytest-cov>=2.6.0
 pytest-html>=1.19.0
-pytest-rerunfailures>=4.2
-pytest-xdist>=1.24.0
+pytest-rerunfailures>=5.0
+pytest-xdist>=1.24.1
 parameterized==0.6.1
 beautifulsoup4>=4.6.0
 pyotp>=2.2.7

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2734,7 +2734,7 @@ class BaseCase(unittest.TestCase):
         """
         has_exception = False
         if sys.version.startswith('3') and hasattr(self, '_outcome'):
-            if self._outcome.errors:
+            if hasattr(self._outcome, 'errors') and self._outcome.errors:
                 has_exception = True
         else:
             has_exception = sys.exc_info()[1] is not None

--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,11 @@ setup(
         'selenium==3.141.0',
         'requests==2.20.0',  # Changing this may effect "urllib3"
         'urllib3==1.24.1',  # Keep this lib in sync with "requests"
-        'pytest>=3.10.0',
+        'pytest>=4.0.0',
         'pytest-cov>=2.6.0',
         'pytest-html>=1.19.0',
-        'pytest-rerunfailures>=4.2',
-        'pytest-xdist>=1.24.0',
+        'pytest-rerunfailures>=5.0',
+        'pytest-xdist>=1.24.1',
         'parameterized==0.6.1',
         'beautifulsoup4>=4.6.0',  # Keep at >=4.6.0 while using bs4
         'pyotp>=2.2.7',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.17.3',
+    version='1.17.4',
     description='All-in-One Test Automation Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fix edge case with BaseCase tearDown() method
* If running tests with ``--pdb``, tests would fail if there were no errors. Now fixed.