### PR TITLE
Set default selector to "html" for text-search methods

### DIFF
--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -69,7 +69,7 @@ self.is_link_text_visible(link_text)
 
 self.is_partial_link_text_visible(partial_link_text)
 
-self.is_text_visible(text, selector, by=By.CSS_SELECTOR)
+self.is_text_visible(text, selector="html", by=By.CSS_SELECTOR)
 
 self.find_elements(selector, by=By.CSS_SELECTOR)
 
@@ -240,19 +240,19 @@ self.assert_element(
 
 ########
 
-self.wait_for_text_visible(text, selector, by=By.CSS_SELECTOR,
+self.wait_for_text_visible(text, selector="html", by=By.CSS_SELECTOR,
     timeout=settings.LARGE_TIMEOUT)
 
-self.wait_for_text(text, selector, by=By.CSS_SELECTOR,
+self.wait_for_text(text, selector="html", by=By.CSS_SELECTOR,
     timeout=settings.LARGE_TIMEOUT)
 
-self.find_text(text, selector, by=By.CSS_SELECTOR,
+self.find_text(text, selector="html", by=By.CSS_SELECTOR,
     timeout=settings.LARGE_TIMEOUT)
 
-self.assert_text_visible(text, selector, by=By.CSS_SELECTOR,
+self.assert_text_visible(text, selector="html", by=By.CSS_SELECTOR,
     timeout=settings.SMALL_TIMEOUT)
 
-self.assert_text(text, selector, by=By.CSS_SELECTOR,
+self.assert_text(text, selector="html", by=By.CSS_SELECTOR,
     timeout=settings.SMALL_TIMEOUT)
 
 ########
@@ -315,7 +315,7 @@ self.switch_to_default_window()
 self.save_screenshot(name, folder=None)
 
 self.get_new_driver(browser=None, headless=None, servername=None, port=None,
-                    proxy=None, switch_to=True)
+                    proxy=None, switch_to=True, cap_file=None)
 
 self.switch_to_driver(driver)
 
@@ -326,7 +326,7 @@ self.switch_to_default_driver()
 self.delayed_assert_element(selector, by=By.CSS_SELECTOR,
     timeout=settings.MINI_TIMEOUT)
 
-self.delayed_assert_text(text, selector, by=By.CSS_SELECTOR,
+self.delayed_assert_text(text, selector="html", by=By.CSS_SELECTOR,
     timeout=settings.MINI_TIMEOUT)
 
 self.process_delayed_asserts()

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -633,7 +633,7 @@ class BaseCase(unittest.TestCase):
         return page_actions.is_element_visible(self.driver, partial_link_text,
                                                by=By.PARTIAL_LINK_TEXT)
 
-    def is_text_visible(self, text, selector, by=By.CSS_SELECTOR):
+    def is_text_visible(self, text, selector="html", by=By.CSS_SELECTOR):
         self.wait_for_ready_state_complete()
         time.sleep(0.01)
         if page_utils.is_xpath_selector(selector):
@@ -1946,7 +1946,7 @@ class BaseCase(unittest.TestCase):
     # with the exception of assert_*, which won't return the element,
     # but like the others, will raise an exception if the call fails.
 
-    def wait_for_text_visible(self, text, selector, by=By.CSS_SELECTOR,
+    def wait_for_text_visible(self, text, selector="html", by=By.CSS_SELECTOR,
                               timeout=settings.LARGE_TIMEOUT):
         if self.timeout_multiplier and timeout == settings.LARGE_TIMEOUT:
             timeout = self.__get_new_timeout(timeout)
@@ -1958,7 +1958,7 @@ class BaseCase(unittest.TestCase):
         return page_actions.wait_for_text_visible(
             self.driver, text, selector, by, timeout)
 
-    def wait_for_text(self, text, selector, by=By.CSS_SELECTOR,
+    def wait_for_text(self, text, selector="html", by=By.CSS_SELECTOR,
                       timeout=settings.LARGE_TIMEOUT):
         """ The shorter version of wait_for_text_visible() """
         if self.timeout_multiplier and timeout == settings.LARGE_TIMEOUT:
@@ -1966,7 +1966,7 @@ class BaseCase(unittest.TestCase):
         return self.wait_for_text_visible(
             text, selector, by=by, timeout=timeout)
 
-    def find_text(self, text, selector, by=By.CSS_SELECTOR,
+    def find_text(self, text, selector="html", by=By.CSS_SELECTOR,
                   timeout=settings.LARGE_TIMEOUT):
         """ Same as wait_for_text_visible() - returns the element """
         if self.timeout_multiplier and timeout == settings.LARGE_TIMEOUT:
@@ -1974,14 +1974,14 @@ class BaseCase(unittest.TestCase):
         return self.wait_for_text_visible(
             text, selector, by=by, timeout=timeout)
 
-    def assert_text_visible(self, text, selector, by=By.CSS_SELECTOR,
+    def assert_text_visible(self, text, selector="html", by=By.CSS_SELECTOR,
                             timeout=settings.SMALL_TIMEOUT):
         """ Same as assert_text() """
         if self.timeout_multiplier and timeout == settings.SMALL_TIMEOUT:
             timeout = self.__get_new_timeout(timeout)
         return self.assert_text(text, selector, by=by, timeout=timeout)
 
-    def assert_text(self, text, selector, by=By.CSS_SELECTOR,
+    def assert_text(self, text, selector="html", by=By.CSS_SELECTOR,
                     timeout=settings.SMALL_TIMEOUT):
         """ Similar to wait_for_text_visible()
             Raises an exception if the element or the text is not found.
@@ -2378,7 +2378,7 @@ class BaseCase(unittest.TestCase):
         """ DEPRECATED - Use self.delayed_assert_element() instead. """
         return self.delayed_assert_element(selector, by=by, timeout=timeout)
 
-    def delayed_assert_text(self, text, selector, by=By.CSS_SELECTOR,
+    def delayed_assert_text(self, text, selector="html", by=By.CSS_SELECTOR,
                             timeout=settings.MINI_TIMEOUT):
         """ A non-terminating assertion for text from an element on a page.
             Failures will be saved until the process_delayed_asserts()
@@ -2400,7 +2400,7 @@ class BaseCase(unittest.TestCase):
             return False
 
     @decorators.deprecated("Use self.delayed_assert_text() instead!")
-    def check_assert_text(self, text, selector, by=By.CSS_SELECTOR,
+    def check_assert_text(self, text, selector="html", by=By.CSS_SELECTOR,
                           timeout=settings.MINI_TIMEOUT):
         """ DEPRECATED - Use self.delayed_assert_text() instead. """
         return self.delayed_assert_text(text, selector, by=by, timeout=timeout)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.17.5',
+    version='1.17.6',
     description='All-in-One Test Automation Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Set default selector to ``html`` for text-search methods.
(It's also optional now.)

Now you can do something like this:
```python
self.assert_text("SOME TEXT")
```
instead of this:
```python
self.assert_text("SOME TEXT", "html")
```
(Default selector type for selectors: ``by=By.CSS_SELECTOR``)

Methods effected:
``assert_text``
``is_text_visible``
``wait_for_text``
``find_text``
``delayed_assert_text``
``wait_for_text_visible``
``assert_text_visible``

Due to keeping backwards compatibility, a few older methods remain that do the same thing as newer methods. (Method names were shortened from their previous versions.)