### PR TITLE
Add method/option to check for Javascript errors on page loads

### DIFF
--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -174,6 +174,8 @@ self.is_downloaded_file_present(file)
 
 self.assert_downloaded_file(file)
 
+self.assert_no_js_errors()
+
 self.get_google_auth_password(totp_key=None)
 
 self.convert_xpath_to_css(xpath)

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -1514,6 +1514,29 @@ class BaseCase(unittest.TestCase):
         """ Asserts that the file exists in the Downloads Folder. """
         assert os.path.exists(self.get_path_of_downloaded_file(file))
 
+    def assert_no_js_errors(self):
+        """ Asserts that there are no Javascript errors on the page.
+            Only looks for "SEVERE"-level errors.
+            Works best when using Chrome.
+            Does NOT work on Firefox:
+                * See https://github.com/SeleniumHQ/selenium/issues/1161
+            Based on the following Stack Overflow solution:
+                * https://stackoverflow.com/a/41150512/7058266 """
+        try:
+            browser_logs = self.driver.get_log('browser')
+        except (ValueError, WebDriverException):
+            # If unable to get browser logs, skip the assert and return.
+            return
+
+        errors = []
+        for entry in browser_logs:
+            if entry['level'] == 'SEVERE':
+                errors.append(entry)
+        if len(errors) > 0:
+            current_url = self.get_current_url()
+            raise Exception(
+                "Javascript errors found on %s => %s" % (current_url, errors))
+
     def get_google_auth_password(self, totp_key=None):
         """ Returns a time-based one-time password based on the
             Google Authenticator password algorithm. Works with Authy.

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2150,6 +2150,8 @@ class BaseCase(unittest.TestCase):
             timeout = self.__get_new_timeout(timeout)
         is_ready = js_utils.wait_for_ready_state_complete(self.driver, timeout)
         self.wait_for_angularjs(timeout=settings.MINI_TIMEOUT)
+        if self.js_checking_on:
+            self.assert_no_js_errors()
         if self.ad_block_on:
             # If the ad_block feature is enabled, then block ads for new URLs
             current_url = self.get_current_url()
@@ -2663,6 +2665,7 @@ class BaseCase(unittest.TestCase):
             self.demo_sleep = pytest.config.option.demo_sleep
             self.highlights = pytest.config.option.highlights
             self.message_duration = pytest.config.option.message_duration
+            self.js_checking_on = pytest.config.option.js_checking_on
             self.ad_block_on = pytest.config.option.ad_block_on
             self.verify_delay = pytest.config.option.verify_delay
             self.timeout_multiplier = pytest.config.option.timeout_multiplier

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -125,6 +125,11 @@ def pytest_addoption(parser):
                      help="""Setting this overrides the default time that
                           messenger notifications remain visible when reaching
                           assert statements during Demo Mode.""")
+    parser.addoption('--check_js', action="store_true",
+                     dest='js_checking_on',
+                     default=False,
+                     help="""The option to check for Javascript errors after
+                          every page load.""")
     parser.addoption('--ad_block', action="store_true",
                      dest='ad_block_on',
                      default=False,

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -24,6 +24,7 @@ class SeleniumBrowser(Plugin):
     self.options.demo_sleep -- Selenium action delay in DemoMode (--demo_sleep)
     self.options.highlights -- # of highlight animations shown (--highlights)
     self.options.message_duration -- Messenger alert time (--message_duration)
+    self.options.js_checking_on -- option to check for js errors (--check_js)
     self.options.ad_block -- the option to block some display ads (--ad_block)
     self.options.verify_delay -- delay before MasterQA checks (--verify_delay)
     self.options.timeout_multiplier -- increase defaults (--timeout_multiplier)
@@ -101,6 +102,12 @@ class SeleniumBrowser(Plugin):
                     messenger notifications remain visible when reaching
                     assert statements during Demo Mode.""")
         parser.add_option(
+            '--check_js', action="store_true",
+            dest='js_checking_on',
+            default=False,
+            help="""The option to check for Javascript errors after
+                    every page load.""")
+        parser.add_option(
             '--ad_block', action="store_true",
             dest='ad_block_on',
             default=False,
@@ -137,6 +144,7 @@ class SeleniumBrowser(Plugin):
         test.test.demo_sleep = self.options.demo_sleep
         test.test.highlights = self.options.highlights
         test.test.message_duration = self.options.message_duration
+        test.test.js_checking_on = self.options.js_checking_on
         test.test.ad_block_on = self.options.ad_block_on
         test.test.verify_delay = self.options.verify_delay  # MasterQA
         test.test.timeout_multiplier = self.options.timeout_multiplier

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.17.7',
+    version='1.17.8',
     description='All-in-One Test Automation Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Add method/option to check for Javascript errors on page loads:
* New method:
```python
self.assert_no_js_errors()
```
* New command line option:
```bash
--check_js
```
(When the command line option is turned on, Selenium will check for Javascript errors after every page load.)