### PR TITLE
Add click_visible_elements(selector) method

### DIFF
--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -75,6 +75,8 @@ self.find_elements(selector, by=By.CSS_SELECTOR)
 
 self.find_visible_elements(selector, by=By.CSS_SELECTOR)
 
+self.click_visible_elements(selector, by=By.CSS_SELECTOR)
+
 self.is_element_in_an_iframe(selector, by=By.CSS_SELECTOR)
 
 self.switch_to_frame_of_element(selector, by=By.CSS_SELECTOR)

--- a/seleniumbase/config/proxy_list.py
+++ b/seleniumbase/config/proxy_list.py
@@ -15,14 +15,14 @@ Format of PROXY_LIST server entries:
 Example proxies in PROXY_LIST below are not guaranteed to be active or secure.
 If you don't already have a proxy server to connect to,
 you can try finding one from one of following sites:
-* https://www.proxynova.com/proxy-server-list/port-8080/
+* https://www.proxynova.com/proxy-server-list/country-us/
 * https://www.us-proxy.org/
 * https://hidemy.name/en/proxy-list/?country=US&type=h#list
 * http://proxyservers.pro/proxy/list/protocol/http/country/US/
 """
 
 PROXY_LIST = {
-    "example1": "104.248.122.30:8080",  # (Example) - set your own proxy here
+    "example1": "192.241.132.219:80",  # (Example) - set your own proxy here
     "proxy1": None,
     "proxy2": None,
     "proxy3": None,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.17.8',
+    version='1.17.9',
     description='All-in-One Test Automation Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Add click_visible_elements(selector) method

Finds all matching page elements and clicks visible ones in order.
If a click reloads or opens a new page, the clicking will stop.
Works best for actions such as clicking all checkboxes on a page.

Example:
```python
self.click_visible_elements('input[type="checkbox"]')
```


