### PR TITLE
Mostly replacing a pytest deprecated call with a new one

### DIFF
--- a/seleniumbase/console_scripts/run.py
+++ b/seleniumbase/console_scripts/run.py
@@ -189,7 +189,7 @@ def main():
             show_basic_usage()
             show_mkdir_usage()
     elif command == "download":
-        if len(command_args) >= 1:
+        if len(command_args) >= 1 and command_args[0].lower() == "server":
             download_selenium_server.main(force_download=True)
         else:
             show_basic_usage()

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -31,6 +31,7 @@ import time
 import unittest
 import uuid
 from bs4 import BeautifulSoup
+from seleniumbase import config as sb_config
 from seleniumbase.common import decorators
 from seleniumbase.config import settings
 from seleniumbase.core.application_manager import ApplicationManager
@@ -2727,7 +2728,7 @@ class BaseCase(unittest.TestCase):
         self.is_pytest = None
         try:
             # This raises an exception if the test is not coming from pytest
-            self.is_pytest = pytest.config.option.is_pytest
+            self.is_pytest = sb_config.is_pytest
         except Exception:
             # Not using pytest (probably nosetests)
             self.is_pytest = False
@@ -2736,34 +2737,33 @@ class BaseCase(unittest.TestCase):
             test_id = "%s.%s.%s" % (self.__class__.__module__,
                                     self.__class__.__name__,
                                     self._testMethodName)
-            self.environment = pytest.config.option.environment
+            self.browser = sb_config.browser
+            self.data = sb_config.data
+            self.demo_mode = sb_config.demo_mode
+            self.demo_sleep = sb_config.demo_sleep
+            self.highlights = sb_config.highlights
+            self.environment = sb_config.environment
             self.env = self.environment  # Add a shortened version
-            self.with_selenium = pytest.config.option.with_selenium
-            self.headless = pytest.config.option.headless
+            self.with_selenium = sb_config.with_selenium  # Should be True
+            self.headless = sb_config.headless
             self.headless_active = False
-            self.with_testing_base = pytest.config.option.with_testing_base
-            self.with_db_reporting = pytest.config.option.with_db_reporting
-            self.with_s3_logging = pytest.config.option.with_s3_logging
-            self.with_screen_shots = pytest.config.option.with_screen_shots
-            self.with_basic_test_info = (
-                pytest.config.option.with_basic_test_info)
-            self.with_page_source = pytest.config.option.with_page_source
-            self.servername = pytest.config.option.servername
-            self.port = pytest.config.option.port
-            self.proxy_string = pytest.config.option.proxy_string
-            self.cap_file = pytest.config.option.cap_file
-            self.database_env = pytest.config.option.database_env
-            self.log_path = pytest.config.option.log_path
-            self.browser = pytest.config.option.browser
-            self.data = pytest.config.option.data
-            self.demo_mode = pytest.config.option.demo_mode
-            self.demo_sleep = pytest.config.option.demo_sleep
-            self.highlights = pytest.config.option.highlights
-            self.message_duration = pytest.config.option.message_duration
-            self.js_checking_on = pytest.config.option.js_checking_on
-            self.ad_block_on = pytest.config.option.ad_block_on
-            self.verify_delay = pytest.config.option.verify_delay
-            self.timeout_multiplier = pytest.config.option.timeout_multiplier
+            self.log_path = sb_config.log_path
+            self.with_testing_base = sb_config.with_testing_base
+            self.with_basic_test_info = sb_config.with_basic_test_info
+            self.with_screen_shots = sb_config.with_screen_shots
+            self.with_page_source = sb_config.with_page_source
+            self.with_db_reporting = sb_config.with_db_reporting
+            self.with_s3_logging = sb_config.with_s3_logging
+            self.servername = sb_config.servername
+            self.port = sb_config.port
+            self.proxy_string = sb_config.proxy_string
+            self.cap_file = sb_config.cap_file
+            self.database_env = sb_config.database_env
+            self.message_duration = sb_config.message_duration
+            self.js_checking_on = sb_config.js_checking_on
+            self.ad_block_on = sb_config.ad_block_on
+            self.verify_delay = sb_config.verify_delay
+            self.timeout_multiplier = sb_config.timeout_multiplier
             self.use_grid = False
             if self.servername != "localhost":
                 # Use Selenium Grid (Use --server=127.0.0.1 for localhost Grid)
@@ -2898,7 +2898,7 @@ class BaseCase(unittest.TestCase):
         self.is_pytest = None
         try:
             # This raises an exception if the test is not coming from pytest
-            self.is_pytest = pytest.config.option.is_pytest
+            self.is_pytest = sb_config.is_pytest
         except Exception:
             # Not using pytest (probably nosetests)
             self.is_pytest = False

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -2,6 +2,7 @@
 
 import optparse
 import pytest
+from seleniumbase import config as sb_config
 from seleniumbase.core import log_helper
 from seleniumbase.core import proxy_helper
 from seleniumbase.fixtures import constants
@@ -149,10 +150,35 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     """ This runs after command line options have been parsed """
-    with_testing_base = config.getoption('with_testing_base')
-    if with_testing_base:
-        log_path = config.getoption('log_path')
-        log_helper.log_folder_setup(log_path)
+    sb_config.is_pytest = True
+    sb_config.browser = config.getoption('browser')
+    sb_config.data = config.getoption('data')
+    sb_config.environment = config.getoption('environment')
+    sb_config.with_selenium = config.getoption('with_selenium')
+    sb_config.headless = config.getoption('headless')
+    sb_config.with_testing_base = config.getoption('with_testing_base')
+    sb_config.with_db_reporting = config.getoption('with_db_reporting')
+    sb_config.with_s3_logging = config.getoption('with_s3_logging')
+    sb_config.with_screen_shots = config.getoption('with_screen_shots')
+    sb_config.with_basic_test_info = config.getoption('with_basic_test_info')
+    sb_config.with_page_source = config.getoption('with_page_source')
+    sb_config.servername = config.getoption('servername')
+    sb_config.port = config.getoption('port')
+    sb_config.proxy_string = config.getoption('proxy_string')
+    sb_config.cap_file = config.getoption('cap_file')
+    sb_config.database_env = config.getoption('database_env')
+    sb_config.log_path = config.getoption('log_path')
+    sb_config.demo_mode = config.getoption('demo_mode')
+    sb_config.demo_sleep = config.getoption('demo_sleep')
+    sb_config.highlights = config.getoption('highlights')
+    sb_config.message_duration = config.getoption('message_duration')
+    sb_config.js_checking_on = config.getoption('js_checking_on')
+    sb_config.ad_block_on = config.getoption('ad_block_on')
+    sb_config.verify_delay = config.getoption('verify_delay')
+    sb_config.timeout_multiplier = config.getoption('timeout_multiplier')
+
+    if sb_config.with_testing_base:
+        log_helper.log_folder_setup(sb_config.log_path)
     proxy_helper.remove_proxy_zip_if_present()
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.18.0',
+    version='1.18.1',
     description='Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Mostly replacing a pytest deprecated call with a new one to prevent:
``PytestDeprecationWarning: the `pytest.config` global is deprecated.  Please use `request.config` or `pytest_configure` (if you're a pytest plugin) instead.``

The solution involved using ``sb_config`` in place of ``pytest.config.option``

Unrelated, there's also a small update to fix a console script used for downloading the selenium server jar file. (It's only needed when you're trying to run your own Selenium Grid)