### PR TITLE
Update requirements and a few other things

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,16 +8,16 @@ unittest2
 selenium==3.141.0
 requests==2.21.0
 urllib3==1.24.1
-pytest>=4.1.1
+pytest>=4.2.0
 pytest-cov>=2.6.1
 pytest-html>=1.20.0
 pytest-rerunfailures>=6.0
-pytest-xdist>=1.26.0
+pytest-xdist>=1.26.1
 parameterized==0.6.3
 beautifulsoup4>=4.6.0
 colorama==0.4.1
 pyotp>=2.2.7
 boto>=2.49.0
-flake8==3.6.0
+flake8==3.7.3
 PyVirtualDisplay==0.2.1
 -e .

--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -69,6 +69,11 @@ HIGHLIGHTS = 4
 # Messenger notifications appear when reaching assert statements in Demo Mode.
 DEFAULT_MESSAGE_DURATION = 2.55
 
+# If True, an Exception is raised immediately for invalid proxy string syntax.
+# If False, a Warning will appear after the test, with no proxy server used.
+# (This applies when using --proxy=[PROXY_STRING] for using a proxy server.)
+RAISE_INVALID_PROXY_STRING_EXCEPTION = True
+
 # #####>>>>>----- MasterQA SETTINGS -----<<<<<#####
 # ##### (Used when importing MasterQA as the parent class)
 

--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -25,9 +25,8 @@ ARCHIVE_EXISTING_LOGS = False
 # If False, only the downloads from the most recent run will be saved locally.
 ARCHIVE_EXISTING_DOWNLOADS = False
 
-# Default names for files saved during test failures when logging is turned on.
+# Default names for files saved during test failures.
 # (These files will get saved to the "latest_logs/" folder)
-# Usage: "--with-testing_base"
 SCREENSHOT_NAME = "screenshot.png"
 BASIC_INFO_NAME = "basic_test_info.txt"
 PAGE_SOURCE_NAME = "page_source.html"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -87,6 +87,7 @@ def _set_chrome_options(
     chrome_options = webdriver.ChromeOptions()
     prefs = {
         "download.default_directory": downloads_path,
+        "local_discovery.notifications_enabled": False,
         "credentials_enable_service": False,
         "profile": {
             "password_manager_enabled": False

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -9,6 +9,7 @@ from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from seleniumbase.config import proxy_list
+from seleniumbase.config import settings
 from seleniumbase.core import download_helper
 from seleniumbase.core import proxy_helper
 from seleniumbase.core import capabilities_parser
@@ -150,12 +151,16 @@ def _create_firefox_profile(downloads_path, proxy_string):
 def display_proxy_warning(proxy_string):
     message = ('\n\nWARNING: Proxy String ["%s"] is NOT in the expected '
                '"ip_address:port" or "server:port" format, '
-               '(OR the key does not exist in proxy_list.PROXY_LIST). '
-               '*** DEFAULTING to NOT USING a Proxy Server! ***'
+               '(OR the key does not exist in '
+               'seleniumbase.config.proxy_list.PROXY_LIST).'
                % proxy_string)
-    warnings.simplefilter('always', Warning)  # See Warnings
-    warnings.warn(message, category=Warning, stacklevel=2)
-    warnings.simplefilter('default', Warning)  # Set Default
+    if settings.RAISE_INVALID_PROXY_STRING_EXCEPTION:
+        raise Exception(message)
+    else:
+        message += ' *** DEFAULTING to NOT USING a Proxy Server! ***'
+        warnings.simplefilter('always', Warning)  # See Warnings
+        warnings.warn(message, category=Warning, stacklevel=2)
+        warnings.simplefilter('default', Warning)  # Set Default
 
 
 def validate_proxy_string(proxy_string):

--- a/setup.py
+++ b/setup.py
@@ -61,17 +61,17 @@ setup(
         'selenium==3.141.0',
         'requests==2.21.0',  # Changing this may effect "urllib3"
         'urllib3==1.24.1',  # Keep this lib in sync with "requests"
-        'pytest>=4.1.1',
+        'pytest>=4.2.0',
         'pytest-cov>=2.6.1',
         'pytest-html>=1.20.0',
         'pytest-rerunfailures>=6.0',
-        'pytest-xdist>=1.26.0',
+        'pytest-xdist>=1.26.1',
         'parameterized==0.6.3',
         'beautifulsoup4>=4.6.0',  # Keep at >=4.6.0 while using bs4
         'colorama==0.4.1',
         'pyotp>=2.2.7',
         'boto>=2.49.0',
-        'flake8==3.6.0',
+        'flake8==3.7.3',
         'PyVirtualDisplay==0.2.1',
     ],
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.18.2',
-    description='Reliable Browser Automation & Testing Framework',
+    version='1.19.0',
+    description='Easy, Fast, Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/seleniumbase/SeleniumBase',


### PR DESCRIPTION
Update requirements and a few other things:
* Updated requirements: ``pytest>=4.2.0``, ``pytest-xdist>=1.26.1``, ``flake8==3.7.3``.
* Add option to raise a Python Exception immediately when specifying an invalid proxy string, rather than waiting to display a warning message at the end of the test run (without using a proxy server). Usage: ``--proxy=[PROXY_STRING]``.
* Disable Chrome local_discovery pop-up notifications, such as "New printer on your network".