### PR TITLE
Update webdriver installation script

### DIFF
--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -53,9 +53,6 @@ This adds wait_for_angularjs() after various browser actions.
 '''
 WAIT_FOR_ANGULARJS = True
 
-# Option to start Chrome in full screen mode by default
-START_CHROME_IN_FULL_SCREEN_MODE = False
-
 # Default time to wait after each browser action performed during Demo Mode.
 # Use Demo Mode when you want others to see what your automation is doing.
 # Usage: "--demo_mode". (Can be overwritten by using "--demo_sleep=TIME".)

--- a/seleniumbase/console_scripts/sb_install.py
+++ b/seleniumbase/console_scripts/sb_install.py
@@ -71,16 +71,17 @@ def main():
     inner_folder = None
 
     if name == "chromedriver":
+        latest_version = "2.46"
         if "darwin" in sys_plat:
             file_name = "chromedriver_mac64.zip"
         elif "linux" in sys_plat:
+            latest_version = "2.40"  # Linux machines may need the old driver
             file_name = "chromedriver_linux64.zip"
         elif "win32" in sys_plat or "win64" in sys_plat or "x64" in sys_plat:
             file_name = "chromedriver_win32.zip"  # Works for win32 / win_x64
         else:
             raise Exception("Cannot determine which version of Chromedriver "
                             "to download!")
-        latest_version = "2.40"
         download_url = ("http://chromedriver.storage.googleapis.com/"
                         "%s/%s" % (latest_version, file_name))
         # Forcing Chromedriver v2.40 for now, even though it's not the latest.
@@ -98,7 +99,7 @@ def main():
                                 "%s/%s" % (latest_version, file_name))
             print("Found %s" % download_url)
     elif name == "geckodriver" or name == "firefoxdriver":
-        latest_version = "v0.23.0"
+        latest_version = "v0.24.0"
         if "darwin" in sys_plat:
             file_name = "geckodriver-%s-macos.tar.gz" % latest_version
         elif "linux" in sys_plat:
@@ -140,7 +141,7 @@ def main():
                         "%s/%s" % (major_version, file_name))
     elif name == "operadriver" or name == "operachromiumdriver":
         name = "operadriver"
-        latest_version = "v.2.37"
+        latest_version = "v.2.40"
         if "darwin" in sys_plat:
             file_name = "operadriver_mac64.zip"
             platform_code = "mac64"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2428,12 +2428,15 @@ class BaseCase(unittest.TestCase):
                     # WebDrivers can get closed during tearDown().
                     pass
             else:
-                if self.browser == 'chrome':
+                if self.browser == 'chrome' or self.browser == 'opera':
                     try:
-                        if settings.START_CHROME_IN_FULL_SCREEN_MODE:
-                            self.driver.maximize_window()
-                        else:
-                            self.driver.set_window_size(1250, 840)
+                        self.driver.set_window_size(1250, 840)
+                        self.wait_for_ready_state_complete()
+                    except Exception:
+                        pass  # Keep existing browser resolution
+                elif self.browser == 'edge':
+                    try:
+                        self.driver.maximize_window()
                         self.wait_for_ready_state_complete()
                     except Exception:
                         pass  # Keep existing browser resolution

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.19.8',
+    version='1.19.9',
     description='Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Update webdriver installation script:
* ``seleniumbase install chromedriver`` will now install chromedriver v2.46, except on Linux machines, which may be using older versions of Chrome
* ``seleniumbase install geckodriver`` will now install v0.24.0 (for Firefox)
* ``seleniumbase install operadriver`` will now install v.2.40

Other changes:
* Update starting browser dimensions
