### PR TITLE
 Add limit argument to methods that return or click multiple elements

### DIFF
--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -71,11 +71,11 @@ self.is_partial_link_text_visible(partial_link_text)
 
 self.is_text_visible(text, selector="html", by=By.CSS_SELECTOR)
 
-self.find_elements(selector, by=By.CSS_SELECTOR)
+self.find_elements(selector, by=By.CSS_SELECTOR, limit=0)
 
-self.find_visible_elements(selector, by=By.CSS_SELECTOR)
+self.find_visible_elements(selector, by=By.CSS_SELECTOR, limit=0)
 
-self.click_visible_elements(selector, by=By.CSS_SELECTOR)
+self.click_visible_elements(selector, by=By.CSS_SELECTOR, limit=0)
 
 self.is_element_in_an_iframe(selector, by=By.CSS_SELECTOR)
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.21.0',
+    version='1.21.1',
     description='Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
 Add "limit" argument to methods that return or click multiple elements.
Updated methods:  ("0" means no limit)
* ``self.find_elements(selector, by=By.CSS_SELECTOR, limit=0)``
* ``self.find_visible_elements(selector, by=By.CSS_SELECTOR, limit=0)``
* ``self.click_visible_elements(selector, by=By.CSS_SELECTOR, limit=0)``

Example:
``self.click_visible_elements('[type="checkbox"]', limit=5)``
(Click the first 5 visible checkboxes on a page)