### PR TITLE
Add the ability to save screenshots at the end of tests

### DIFF
--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2801,6 +2801,7 @@ class BaseCase(unittest.TestCase):
             self.js_checking_on = sb_config.js_checking_on
             self.ad_block_on = sb_config.ad_block_on
             self.verify_delay = sb_config.verify_delay
+            self.save_screenshot_after_test = sb_config.save_screenshot
             self.timeout_multiplier = sb_config.timeout_multiplier
             self.use_grid = False
             if self.servername != "localhost":
@@ -2981,6 +2982,12 @@ class BaseCase(unittest.TestCase):
                 # Save a screenshot if logging is on when an exception occurs
                 if has_exception:
                     self.__add_pytest_html_extra()
+                if self.with_testing_base and not has_exception and (
+                        self.save_screenshot_after_test):
+                    test_logpath = self.log_path + "/" + test_id
+                    if not os.path.exists(test_logpath):
+                        os.makedirs(test_logpath)
+                    log_helper.log_screenshot(test_logpath, self.driver)
                 if self.with_testing_base and has_exception:
                     test_logpath = self.log_path + "/" + test_id
                     if not os.path.exists(test_logpath):
@@ -3056,5 +3063,13 @@ class BaseCase(unittest.TestCase):
                 if len(self._drivers_list) > 0:
                     log_helper.log_screenshot(test_logpath, self.driver)
                     log_helper.log_page_source(test_logpath, self.driver)
+            elif self.save_screenshot_after_test:
+                test_id = "%s.%s.%s" % (self.__class__.__module__,
+                                        self.__class__.__name__,
+                                        self._testMethodName)
+                test_logpath = "latest_logs/" + test_id
+                if not os.path.exists(test_logpath):
+                    os.makedirs(test_logpath)
+                log_helper.log_screenshot(test_logpath, self.driver)
             # Finally close all open browser windows
             self.__quit_all_drivers()

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -47,7 +47,13 @@ def pytest_addoption(parser):
     parser.addoption('--with-testing_base', action="store_true",
                      dest='with_testing_base',
                      default=True,
-                     help="Use to save logs (screenshots) when tests fail.")
+                     help="""Use to save logs and screenshots when tests fail.
+                          It's no longer needed to add the following arguments:
+                          --with-screen_shots
+                          --with-basic_test_info
+                          --with-page_source
+                          (Those modes are all active by default now when
+                          --with-testing_base is active. (Default: active)""")
     parser.addoption('--log_path', dest='log_path',
                      default='latest_logs/',
                      help='Where the log files are saved.')
@@ -70,15 +76,18 @@ def pytest_addoption(parser):
     parser.addoption('--with-screen_shots', action="store_true",
                      dest='with_screen_shots',
                      default=False,
-                     help="Use to save screenshots on test failure.")
+                     help="""Use to save screenshots on test failure.
+                          (When "--with-testing_base" is True, this is on.)""")
     parser.addoption('--with-basic_test_info', action="store_true",
                      dest='with_basic_test_info',
                      default=False,
-                     help="Use to save basic test info on test failure.")
+                     help="""Use to save basic test info on test failure.
+                          (When "--with-testing_base" is True, this is on.)""")
     parser.addoption('--with-page_source', action="store_true",
                      dest='with_page_source',
                      default=False,
-                     help="Use to save page source on test failure.")
+                     help="""Use to save page source on test failure.
+                          (When "--with-testing_base" is True, this is on.)""")
     parser.addoption('--server', action='store',
                      dest='servername',
                      default='localhost',
@@ -146,6 +155,11 @@ def pytest_addoption(parser):
                      default=None,
                      help="""Setting this overrides the default wait time
                           before each MasterQA verification pop-up.""")
+    parser.addoption('--save_screenshot', action='store_true',
+                     dest='save_screenshot',
+                     default=False,
+                     help="""Take a screenshot on last page after the last step
+                          of the test. (Added to the "latest_logs" folder.)""")
     parser.addoption('--timeout_multiplier', action='store',
                      dest='timeout_multiplier',
                      default=None,
@@ -182,6 +196,7 @@ def pytest_configure(config):
     sb_config.js_checking_on = config.getoption('js_checking_on')
     sb_config.ad_block_on = config.getoption('ad_block_on')
     sb_config.verify_delay = config.getoption('verify_delay')
+    sb_config.save_screenshot = config.getoption('save_screenshot')
     sb_config.timeout_multiplier = config.getoption('timeout_multiplier')
 
     if sb_config.with_testing_base:

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -28,6 +28,7 @@ class SeleniumBrowser(Plugin):
     self.options.js_checking_on -- option to check for js errors (--check_js)
     self.options.ad_block -- the option to block some display ads (--ad_block)
     self.options.verify_delay -- delay before MasterQA checks (--verify_delay)
+    self.options.save_screenshot -- save screen after test (--save_screenshot)
     self.options.timeout_multiplier -- increase defaults (--timeout_multiplier)
     """
     name = 'selenium'  # Usage: --with-selenium
@@ -127,6 +128,12 @@ class SeleniumBrowser(Plugin):
             help="""Setting this overrides the default wait time
                     before each MasterQA verification pop-up.""")
         parser.add_option(
+            '--save_screenshot', action="store_true",
+            dest='save_screenshot',
+            default=False,
+            help="""Take a screenshot on last page after the last step
+                    of the test. (Added to the "latest_logs" folder.)""")
+        parser.add_option(
             '--timeout_multiplier', action='store',
             dest='timeout_multiplier',
             default=None,
@@ -156,6 +163,7 @@ class SeleniumBrowser(Plugin):
         test.test.js_checking_on = self.options.js_checking_on
         test.test.ad_block_on = self.options.ad_block_on
         test.test.verify_delay = self.options.verify_delay  # MasterQA
+        test.test.save_screenshot_after_test = self.options.save_screenshot
         test.test.timeout_multiplier = self.options.timeout_multiplier
         test.test.use_grid = False
         if test.test.servername != "localhost":

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.21.1',
+    version='1.21.2',
     description='Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Add the ability to save screenshots at the end of tests.
This adds the feature for passing tests. (This feature already existed for failing tests automatically.)
Check the latest_logs folder for the images.

Usage: (on the command line when running tests)
* ``--save_screenshot``

The screenshot will be taken right before the browser is closed.