### PR TITLE
Add a command-line option to archive old log files rather than deleting them.

### DIFF
--- a/seleniumbase/core/log_helper.py
+++ b/seleniumbase/core/log_helper.py
@@ -101,7 +101,7 @@ def get_html_source_with_base_href(driver, page_source):
     return ''
 
 
-def log_folder_setup(log_path):
+def log_folder_setup(log_path, archive_logs=False):
     """ Handle Logging """
     if log_path.endswith("/"):
         log_path = log_path[:-1]
@@ -125,5 +125,5 @@ def log_folder_setup(log_path):
                 archived_folder, int(time.time()))
             shutil.move(log_path, archived_logs)
             os.makedirs(log_path)
-            if not settings.ARCHIVE_EXISTING_LOGS:
+            if not settings.ARCHIVE_EXISTING_LOGS and not archive_logs:
                 shutil.rmtree(archived_logs)

--- a/seleniumbase/plugins/base_plugin.py
+++ b/seleniumbase/plugins/base_plugin.py
@@ -17,20 +17,18 @@ from seleniumbase.fixtures import constants, errors
 
 class Base(Plugin):
     """
-    The base_plugin includes the following variables for nosetest runs:
-    self.env -- The environment for the tests to use (Usage: --env=ENV)
-    self.data -- Any extra data to pass to the tests (Usage: --data=DATA)
-    self.log_path -- The directory where log files get saved to
-                     (Usage: --log_path=LOG_PATH)
-    self.report -- The option to create a fancy report after tests complete
-                   (Usage: --report)
-    self.show_report -- If self.report is turned on, then the report will
-                        display immediately after tests complete their run.
-                        Only use this when running tests locally, as this will
-                        pause the test run until the report window is closed.
-                        (Usage: --show_report)
+    The base_plugin includes the following command-line options for nosetests:
+    --env=ENV  (Set a test environment. Use "self.env" to access env in tests.)
+    --data=DATA  (Extra data to pass to tests. Use "self.data" in tests.)
+    --log_path=LOG_PATH  (The directory where log files get saved to.)
+    --archive_logs  (Archive old log files instead of deleting them.)
+    --report  (The option to create a fancy report after tests complete.)
+    --show_report   If self.report is turned on, then the report will
+                    display immediately after tests complete their run.
+                    Only use this when running tests locally, as this will
+                    pause the test run until the report window is closed.
     """
-    name = 'testing_base'  # Usage: --with-testing_base
+    name = 'testing_base'  # Usage: --with-testing_base  (Enabled by default)
 
     def options(self, parser, env):
         super(Base, self).options(parser, env=env)
@@ -55,6 +53,11 @@ class Base(Plugin):
             '--log_path', dest='log_path',
             default='latest_logs/',
             help='Where the log files are saved.')
+        parser.add_option(
+            '--archive_logs', action="store_true",
+            dest='archive_logs',
+            default=False,
+            help="Archive old log files instead of deleting them.")
         parser.add_option(
             '--report', action="store_true", dest='report',
             default=False,
@@ -89,7 +92,8 @@ class Base(Plugin):
         self.test_count = 0
         self.import_error = False
         log_path = options.log_path
-        log_helper.log_folder_setup(log_path)
+        archive_logs = options.archive_logs
+        log_helper.log_folder_setup(log_path, archive_logs)
         if self.report_on:
             report_helper.clear_out_old_report_logs(archive_past_runs=False)
 

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -57,6 +57,10 @@ def pytest_addoption(parser):
     parser.addoption('--log_path', dest='log_path',
                      default='latest_logs/',
                      help='Where the log files are saved.')
+    parser.addoption('--archive_logs', action="store_true",
+                     dest='archive_logs',
+                     default=False,
+                     help="Archive old log files instead of deleting them.")
     parser.addoption('--with-db_reporting', action="store_true",
                      dest='with_db_reporting',
                      default=False,
@@ -189,6 +193,7 @@ def pytest_configure(config):
     sb_config.cap_file = config.getoption('cap_file')
     sb_config.database_env = config.getoption('database_env')
     sb_config.log_path = config.getoption('log_path')
+    sb_config.archive_logs = config.getoption('archive_logs')
     sb_config.demo_mode = config.getoption('demo_mode')
     sb_config.demo_sleep = config.getoption('demo_sleep')
     sb_config.highlights = config.getoption('highlights')
@@ -200,7 +205,7 @@ def pytest_configure(config):
     sb_config.timeout_multiplier = config.getoption('timeout_multiplier')
 
     if sb_config.with_testing_base:
-        log_helper.log_folder_setup(sb_config.log_path)
+        log_helper.log_folder_setup(sb_config.log_path, sb_config.archive_logs)
     proxy_helper.remove_proxy_zip_if_present()
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.21.2',
+    version='1.21.3',
     description='Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Add a command-line option to archive old log files rather than deleting them.

If the option is set, log files from the latest_logs folder will get moved to the archived_logs folder for storage. Otherwise, any existing logs in the latest_logs folder will be deleted at the start of the next test run.

Usage: (on the command line when running tests)
* ``--archive_logs``
