### PR TITLE
Add a command-line option to disable the Content Security Policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ report_archives
 archived_reports
 html_report.html
 report.html
+report.xml
 
 # Tours
 tours_exported

--- a/examples/raw_parameter_script.py
+++ b/examples/raw_parameter_script.py
@@ -36,6 +36,7 @@ except (ImportError, ValueError):
     b.database_env = "test"
     b.log_path = "latest_logs/"
     b.archive_logs = False
+    b.disable_csp = False
     b.save_screenshot_after_test = False
     b.timeout_multiplier = None
     b.with_db_reporting = False

--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -67,10 +67,20 @@ HIGHLIGHTS = 4
 # Messenger notifications appear when reaching assert statements in Demo Mode.
 DEFAULT_MESSAGE_DURATION = 2.55
 
-# If True, the Content Security Policy will be disabled on Chrome and Firefox.
+# If True, the Content Security Policy will be disabled on Firefox.
 # If False, each website's default Content Security Policy will be used.
 # (A website's CSP may prevent SeleniumBase from loading custom JavaScript.)
-DISABLE_CONTENT_SECURITY_POLICY = True
+# If using demo_mode or MasterQA, this value will become True regardless.
+# You can also disable the CSP on the command line by using "--disable_csp".
+DISABLE_CSP_ON_FIREFOX = True
+
+# If True, the Content Security Policy will be disabled on Chrome.
+# If False, each website's default Content Security Policy will be used.
+# (A website's CSP may prevent SeleniumBase from loading custom JavaScript.)
+# If using demo_mode or MasterQA, this value will become True regardless,
+# with the exception of running in headless mode, in which case it'll be False.
+# You can also disable the CSP on the command line by using "--disable_csp".
+DISABLE_CSP_ON_CHROME = False
 
 # If True, an Exception is raised immediately for invalid proxy string syntax.
 # If False, a Warning will appear after the test, with no proxy server used.

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2405,7 +2405,7 @@ class BaseCase(unittest.TestCase):
 
     def get_new_driver(self, browser=None, headless=None,
                        servername=None, port=None, proxy=None, agent=None,
-                       switch_to=True, cap_file=None):
+                       switch_to=True, cap_file=None, disable_csp=None):
         """ This method spins up an extra browser for tests that require
             more than one. The first browser is already provided by tests
             that import base_case.BaseCase from seleniumbase. If parameters
@@ -2473,7 +2473,8 @@ class BaseCase(unittest.TestCase):
                                                  port=port,
                                                  proxy_string=proxy_string,
                                                  user_agent=user_agent,
-                                                 cap_file=cap_file)
+                                                 cap_file=cap_file,
+                                                 disable_csp=disable_csp)
         self._drivers_list.append(new_driver)
         if switch_to:
             self.driver = new_driver
@@ -2843,6 +2844,7 @@ class BaseCase(unittest.TestCase):
             self.js_checking_on = sb_config.js_checking_on
             self.ad_block_on = sb_config.ad_block_on
             self.verify_delay = sb_config.verify_delay
+            self.disable_csp = sb_config.disable_csp
             self.save_screenshot_after_test = sb_config.save_screenshot
             self.timeout_multiplier = sb_config.timeout_multiplier
             self.use_grid = False
@@ -2910,7 +2912,8 @@ class BaseCase(unittest.TestCase):
                                           proxy=self.proxy_string,
                                           agent=self.user_agent,
                                           switch_to=True,
-                                          cap_file=self.cap_file)
+                                          cap_file=self.cap_file,
+                                          disable_csp=self.disable_csp)
         self._default_driver = self.driver
 
     def __insert_test_result(self, state, err):

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2458,6 +2458,10 @@ class BaseCase(unittest.TestCase):
         user_agent = agent
         if user_agent is None:
             user_agent = self.user_agent
+        if disable_csp is None:
+            disable_csp = self.disable_csp
+        if self.demo_mode or self.masterqa_mode:
+            disable_csp = True
         if cap_file is None:
             cap_file = self.cap_file
         valid_browsers = constants.ValidBrowsers.valid_browsers
@@ -2799,12 +2803,13 @@ class BaseCase(unittest.TestCase):
 
     ############
 
-    def setUp(self):
+    def setUp(self, masterqa_mode=False):
         """
         Be careful if a subclass of BaseCase overrides setUp()
         You'll need to add the following line to the subclass setUp() method:
         super(SubClassOfBaseCase, self).setUp()
         """
+        self.masterqa_mode = masterqa_mode
         self.is_pytest = None
         try:
             # This raises an exception if the test is not coming from pytest

--- a/seleniumbase/fixtures/js_utils.py
+++ b/seleniumbase/fixtures/js_utils.py
@@ -125,8 +125,9 @@ def activate_jquery(driver):
     # Since jQuery still isn't activating, give up and raise an exception
     raise Exception(
         '''Unable to load jQuery on "%s" due to a possible violation '''
-        '''of the website's Content Security Policy '''
-        '''directive. ''' % driver.current_url)
+        '''of the website's Content Security Policy directive. '''
+        '''To override this policy, add "--disable_csp" on the '''
+        '''command-line when running your tests.''' % driver.current_url)
 
 
 def are_quotes_escaped(string):

--- a/seleniumbase/masterqa/master_qa.py
+++ b/seleniumbase/masterqa/master_qa.py
@@ -392,7 +392,7 @@ class MasterQA(__MasterQATestCase__):
     def setUp(self):
         self.check_count = 0
         self.auto_close_results_page = False
-        super(__MasterQATestCase__, self).setUp()
+        super(__MasterQATestCase__, self).setUp(masterqa_mode=True)
         self.manual_check_setup()
         if self.headless:
             self.auto_close_results_page = True

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -159,6 +159,15 @@ def pytest_addoption(parser):
                      default=None,
                      help="""Setting this overrides the default wait time
                           before each MasterQA verification pop-up.""")
+    parser.addoption('--disable_csp', action="store_true",
+                     dest='disable_csp',
+                     default=False,
+                     help="""Using this disables the Content Security Policy of
+                          websites, which may interfere with some features of
+                          SeleniumBase, such as loading custom JavaScript
+                          libraries for various testing actions.
+                          Setting this to True (--disable_csp) overrides the
+                          value set in seleniumbase/config/settings.py""")
     parser.addoption('--save_screenshot', action='store_true',
                      dest='save_screenshot',
                      default=False,
@@ -201,6 +210,7 @@ def pytest_configure(config):
     sb_config.js_checking_on = config.getoption('js_checking_on')
     sb_config.ad_block_on = config.getoption('ad_block_on')
     sb_config.verify_delay = config.getoption('verify_delay')
+    sb_config.disable_csp = config.getoption('disable_csp')
     sb_config.save_screenshot = config.getoption('save_screenshot')
     sb_config.timeout_multiplier = config.getoption('timeout_multiplier')
 

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -28,6 +28,7 @@ class SeleniumBrowser(Plugin):
     self.options.js_checking_on -- option to check for js errors (--check_js)
     self.options.ad_block -- the option to block some display ads (--ad_block)
     self.options.verify_delay -- delay before MasterQA checks (--verify_delay)
+    self.options.disable_csp -- disable Content Security Policy (--disable_csp)
     self.options.save_screenshot -- save screen after test (--save_screenshot)
     self.options.timeout_multiplier -- increase defaults (--timeout_multiplier)
     """
@@ -128,6 +129,16 @@ class SeleniumBrowser(Plugin):
             help="""Setting this overrides the default wait time
                     before each MasterQA verification pop-up.""")
         parser.add_option(
+            '--disable_csp', action="store_true",
+            dest='disable_csp',
+            default=False,
+            help="""Using this disables the Content Security Policy of
+                    websites, which may interfere with some features of
+                    SeleniumBase, such as loading custom JavaScript
+                    libraries for various testing actions.
+                    Setting this to True (--disable_csp) overrides the
+                    value set in seleniumbase/config/settings.py""")
+        parser.add_option(
             '--save_screenshot', action="store_true",
             dest='save_screenshot',
             default=False,
@@ -163,6 +174,7 @@ class SeleniumBrowser(Plugin):
         test.test.js_checking_on = self.options.js_checking_on
         test.test.ad_block_on = self.options.ad_block_on
         test.test.verify_delay = self.options.verify_delay  # MasterQA
+        test.test.disable_csp = self.options.disable_csp
         test.test.save_screenshot_after_test = self.options.save_screenshot
         test.test.timeout_multiplier = self.options.timeout_multiplier
         test.test.use_grid = False

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.21.8',
+    version='1.21.9',
     description='Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Add a command-line option to disable the Content Security Policy.
(The CSP may prevent SeleniumBase custom JavaScript abilities from loading on various web pages.)