### PR TITLE
Fix method that finds all links on a web page

### DIFF
--- a/seleniumbase/fixtures/page_utils.py
+++ b/seleniumbase/fixtures/page_utils.py
@@ -13,6 +13,8 @@ def get_domain_url(url):
     Into this:
     https://blog.xkcd.com
     """
+    if "http://" not in url and "https://" not in url:
+        return url
     url_header = url.split('://')[0]
     simple_url = url.split('://')[1]
     base_url = simple_url.split('/')[0]
@@ -71,6 +73,8 @@ def _get_unique_links(page_url, soup):
     Includes:
         "a"->"href", "img"->"src", "link"->"href", and "script"->"src" links.
     """
+    if "http://" not in page_url and "https://" not in page_url:
+        return []
     prefix = 'http:'
     if page_url.startswith('https:'):
         prefix = 'https:'

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.22.0',
+    version='1.22.1',
     description='Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fix method that finds all links on a web page
* Ignore parsing urls on pages that don't have ``://`` in the url (ex: ``about:blank``)