### PR TITLE
Allow passing a boolean value to desired capabilities

### DIFF
--- a/examples/capabilities/ReadMe.md
+++ b/examples/capabilities/ReadMe.md
@@ -41,7 +41,11 @@ You can generate desired capabilities for [BrowserStack](https://www.browserstac
 
 A regex parser was built into SeleniumBase to capture all lines from the specified desired capabilities file in the following formats:
 ``'KEY': 'VALUE'``
+``'KEY': True``
+``'KEY': False``
 ``caps['KEY'] = "VALUE"``
+``caps['KEY'] = True``
+``caps['KEY'] = False``
 (Each pair must be on a separate line. You can interchange single and double quotes.)
 
 You can also swap ``--browser=remote`` with an actual browser, eg ``--browser=chrome``, which will combine the default SeleniumBase desired capabilities with those that were specified in the capabilities file when using ``--cap_file=FILE.py``. Capabilities will override other parameters, so if you set the browser to one thing and the capabilities browser to another, SeleniumBase will use the capabilities browser as the browser. You'll need default SeleniumBase desired capabilities when using a proxy server (not the same as a Selenium Grid server), when downloading files to a desired folder, for disabling some warnings on Chrome, for overriding a website's Content Security Policy on Firefox, and for other reasons.

--- a/seleniumbase/core/capabilities_parser.py
+++ b/seleniumbase/core/capabilities_parser.py
@@ -55,6 +55,46 @@ def get_desired_capabilities(cap_file):
             num_capabilities += 1
             continue
 
+        # "KEY" : True
+        data = re.match(
+            r'''^\s*"([\S\s]+)"\s*:\s*True\s*[,}]?\s*$''', line)
+        if data:
+            key = data.group(1)
+            value = True
+            desired_capabilities[key] = value
+            num_capabilities += 1
+            continue
+
+        # 'KEY' : True
+        data = re.match(
+            r'''^\s*'([\S\s]+)'\s*:\s*True\s*[,}]?\s*$''', line)
+        if data:
+            key = data.group(1)
+            value = True
+            desired_capabilities[key] = value
+            num_capabilities += 1
+            continue
+
+        # "KEY" : False
+        data = re.match(
+            r'''^\s*"([\S\s]+)"\s*:\s*False\s*[,}]?\s*$''', line)
+        if data:
+            key = data.group(1)
+            value = False
+            desired_capabilities[key] = value
+            num_capabilities += 1
+            continue
+
+        # 'KEY' : False
+        data = re.match(
+            r'''^\s*'([\S\s]+)'\s*:\s*False\s*[,}]?\s*$''', line)
+        if data:
+            key = data.group(1)
+            value = False
+            desired_capabilities[key] = value
+            num_capabilities += 1
+            continue
+
         # caps['KEY'] = 'VALUE'
         data = re.match(r"^\s*caps\['([\S\s]+)'\]\s*=\s*'([\S\s]+)'\s*$", line)
         if data:
@@ -89,6 +129,46 @@ def get_desired_capabilities(cap_file):
         if data:
             key = data.group(1)
             value = data.group(2)
+            desired_capabilities[key] = value
+            num_capabilities += 1
+            continue
+
+        # caps["KEY"] = True
+        data = re.match(
+            r'''^\s*caps\["([\S\s]+)"\]\s*=\s*True\s*$''', line)
+        if data:
+            key = data.group(1)
+            value = True
+            desired_capabilities[key] = value
+            num_capabilities += 1
+            continue
+
+        # caps['KEY'] = True
+        data = re.match(
+            r'''^\s*caps\['([\S\s]+)'\]\s*=\s*True\s*$''', line)
+        if data:
+            key = data.group(1)
+            value = True
+            desired_capabilities[key] = value
+            num_capabilities += 1
+            continue
+
+        # caps["KEY"] = False
+        data = re.match(
+            r'''^\s*caps\["([\S\s]+)"\]\s*=\s*False\s*$''', line)
+        if data:
+            key = data.group(1)
+            value = False
+            desired_capabilities[key] = value
+            num_capabilities += 1
+            continue
+
+        # caps['KEY'] = False
+        data = re.match(
+            r'''^\s*caps\['([\S\s]+)'\]\s*=\s*False\s*$''', line)
+        if data:
+            key = data.group(1)
+            value = False
             desired_capabilities[key] = value
             num_capabilities += 1
             continue

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.22.4',
+    version='1.22.5',
     description='Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Allow passing a boolean value to desired capabilities
* All formats as of now:
``'KEY': 'VALUE'``
``'KEY': True``
``'KEY': False``
``caps['KEY'] = "VALUE"``
``caps['KEY'] = True``
``caps['KEY'] = False``
(Each pair must be on a separate line. You can interchange single and double quotes.)
See https://github.com/seleniumbase/SeleniumBase/tree/master/examples/capabilities for the full ReadMe and sample capabilities files.