### PR TITLE
Editable mode install update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ pytest my_first_test.py --demo_mode
 ```
 git clone https://github.com/seleniumbase/SeleniumBase.git
 cd SeleniumBase
-pip install -e .
+pip install -r requirements.txt
+python setup.py develop
 ```
 
 You can also install SeleniumBase from [PyPI](https://pypi.python.org/pypi/seleniumbase): [<img src="https://img.shields.io/badge/pypi-seleniumbase-22AAEE.svg" alt="pypi" />](https://pypi.python.org/pypi/seleniumbase)
@@ -29,7 +30,7 @@ pip install seleniumbase
 
 You can also install a specific GitHub branch of SeleniumBase:
 ```
-pip install -e git+https://github.com/seleniumbase/SeleniumBase.git@master#egg=seleniumbase
+pip install git+https://github.com/seleniumbase/SeleniumBase.git@master#egg=seleniumbase
 ```
 
 ### <img src="https://cdn2.hubspot.net/hubfs/100006/images/super_square_logo_3a.png" title="SeleniumBase" height="32"> Download a web driver:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,9 @@ jobs:
   - script: python -m pip install --upgrade pip && pip install -r requirements.txt
     displayName: 'Install dependencies'
 
+  - script: python setup.py develop
+    displayName: 'Install SeleniumBase'
+
   - script: |
       sudo apt install google-chrome-stable
       sudo apt-get install firefox

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,3 @@ pyotp>=2.2.7
 boto>=2.49.0
 flake8>=3.7.7
 PyVirtualDisplay>=0.2.1
--e .

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.23.5',
+    version='1.23.6',
     description='Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Editable mode install update.
Due to https://github.com/pytest-dev/pytest/issues/5167 (pip 19.1 prevents pytest from being used in editable mode), I'm taking out the default pip editable mode install.
All this really means now is that now you should run ``python setup.py develop`` after installing the requirements.