### PR TITLE
update base version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # SeleniumBase Docker Image
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 #=======================================
 # Install Python and Basic Python Tools


### PR DESCRIPTION
Attempted versions: 1.23.10, 1.17.1

Tried to build the docker image for SeleniumBase, however this appeared:
```
Step 1/30 : FROM ubuntu:17.10
17.10: Pulling from library/ubuntu
4ccdce43d1e0: Pulling fs layer
c95f13c88d92: Pulling fs layer
82656eee95ad: Pulling fs layer
78ff727be57a: Pulling fs layer
448bb314afa5: Pulling fs layer
78ff727be57a: Waiting
448bb314afa5: Waiting
82656eee95ad: Verifying Checksum
82656eee95ad: Download complete
c95f13c88d92: Verifying Checksum
c95f13c88d92: Download complete
4ccdce43d1e0: Verifying Checksum
4ccdce43d1e0: Download complete
448bb314afa5: Verifying Checksum
448bb314afa5: Download complete
78ff727be57a: Verifying Checksum
78ff727be57a: Download complete
4ccdce43d1e0: Pull complete
c95f13c88d92: Pull complete
82656eee95ad: Pull complete
78ff727be57a: Pull complete
448bb314afa5: Pull complete
Digest: sha256:3b811ac794645dfaa47408f4333ac6e433858ff16908965c68f63d5d315acf94
Status: Downloaded newer image for ubuntu:17.10
 ---> e211a66937c6
Step 2/30 : RUN apt-get update && apt-get install -y python python-pip python-setuptools python-dev python-distribute
 ---> Running in eb9eb302807d
Ign:1 http://archive.ubuntu.com/ubuntu artful InRelease
Ign:2 http://archive.ubuntu.com/ubuntu artful-updates InRelease
Ign:3 http://archive.ubuntu.com/ubuntu artful-backports InRelease
Err:4 http://archive.ubuntu.com/ubuntu artful Release
  404  Not Found [IP: 91.189.88.149 80]
Err:5 http://archive.ubuntu.com/ubuntu artful-updates Release
  404  Not Found [IP: 91.189.88.149 80]
Err:6 http://archive.ubuntu.com/ubuntu artful-backports Release
  404  Not Found [IP: 91.189.88.149 80]
Ign:7 http://security.ubuntu.com/ubuntu artful-security InRelease
Err:8 http://security.ubuntu.com/ubuntu artful-security Release
  404  Not Found [IP: 91.189.91.23 80]
Reading package lists...
E: The repository 'http://archive.ubuntu.com/ubuntu artful Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu artful-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu artful-backports Release' does not have a Release file.
E: The repository 'http://security.ubuntu.com/ubuntu artful-security Release' does not have a Release file.
The command '/bin/sh -c apt-get update && apt-get install -y python python-pip python-setuptools python-dev python-distribute' returned a non-zero code: 100
time="2019-05-20T06:30:26Z" level=fatal msg="exit status 100"
```

Wild guess but maybe since `17.10` is no longer maintained from 2018-07-19 the PPA nodes are possibly down ?

As a quick fix I've bumped the base version to `18.04`, seems to build.