### PR TITLE
Fix pytest html reports on Windows

### DIFF
--- a/examples/my_first_test.py
+++ b/examples/my_first_test.py
@@ -4,16 +4,16 @@ from seleniumbase import BaseCase
 class MyTestClass(BaseCase):
 
     def test_basic(self):
-        self.open("https://xkcd.com/353/")           # Navigate browser to page
-        self.assert_element('img[alt="Python"]')       # Assert element on page
-        self.click('a[rel="license"]')                  # Click element on page
-        self.assert_text("free to copy", "div center")    # Assert text in area
+        self.open("https://xkcd.com/353/")
+        self.assert_element('img[alt="Python"]')
+        self.click('a[rel="license"]')
+        self.assert_text("free to copy and reuse")
         self.open("https://xkcd.com/1481/")
-        title = self.get_attribute("#comic img", "title")    # Get an attribute
+        title = self.get_attribute("#comic img", "title")
         self.assert_true("86,400 seconds per day" in title)
-        self.click("link=Blag")                                 # Click on link
+        self.click("link=Blag")
         self.assert_text("The blag of the webcomic", "h2")
-        self.update_text("input#s", "Robots!\n")                    # Type text
+        self.update_text("input#s", "Robots!\n")
         self.assert_text("Hooray robots!", "#content")
         self.open("https://xkcd.com/1319/")
         self.assert_exact_text("Automation", "#ctitle")

--- a/help_docs/happy_customers.md
+++ b/help_docs/happy_customers.md
@@ -1,21 +1,21 @@
 #### Some organizations that've grown their automation with SeleniumBase include:
-* [HubSpot](http://www.hubspot.com/)
-* [Veracode](http://www.veracode.com/)
+* [HubSpot](https://www.hubspot.com/)
+* [Veracode](https://www.veracode.com/)
 * [CA Technologies](https://www.ca.com/)
 * [Broadcom](https://www.broadcom.com/)
 * [iboss](https://www.iboss.com/)
-* [MIT](http://web.mit.edu/)
+* [MIT](https://web.mit.edu/)
 * [Akamai](https://www.akamai.com/)
-* [VMware](http://www.vmware.com/)
-* [Jana](http://jana.com/)
+* [VMware](https://www.vmware.com/)
+* [Jana](https://www.linkedin.com/company/jana)
 * [Raid The Room](http://raidtheroom.com/)
-* [Harvard Medical School](http://hms.harvard.edu/)
+* [Harvard Medical School](https://hms.harvard.edu/)
 * And more...
 
 **Case Study** (*HubSpot*):
 
 In addition to using SeleniumBase for testing the UI of their content management system, HubSpot used SeleniumBase to automate the migration of website pages from one content management system to another, which saved them over one million US dollars and a significant amount of time.
 
-Learn how HubSpot uses SeleniumBase for website testing by reading: [Automated Testing with Selenium](http://dev.hubspot.com/blog/bid/88880/Automated-Integration-Testing-with-Selenium-at-HubSpot#hs_cos_wrapper_name)
+Learn how HubSpot uses SeleniumBase for website testing by reading: [Automated Testing with Selenium](https://dev.hubspot.com/blog/bid/88880/Automated-Integration-Testing-with-Selenium-at-HubSpot#hs_cos_wrapper_name)
 
-For more reading about automation at HubSpot, see: [The Classic "QA Team" is Obsolete](http://product.hubspot.com/blog/the-classic-qa-team-is-obsolete#hs_cos_wrapper_name)
+For more reading about automation at HubSpot, see: [The Classic "QA Team" is Obsolete](https://product.hubspot.com/blog/the-classic-qa-team-is-obsolete#hs_cos_wrapper_name)

--- a/integrations/node_js/my_first_test.py
+++ b/integrations/node_js/my_first_test.py
@@ -7,7 +7,7 @@ class MyTestClass(BaseCase):
         self.open("https://xkcd.com/353/")
         self.assert_element('img[alt="Python"]')
         self.click('a[rel="license"]')
-        self.assert_text("free to copy", "div center")
+        self.assert_text("free to copy and reuse")
         self.open("https://xkcd.com/1481/")
         title = self.get_attribute("#comic img", "title")
         self.assert_true("86,400 seconds per day" in title)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pytest>=4.6.4;python_version<"3"
 pytest>=5.0.1;python_version>="3"
 pytest-cov>=2.7.1
 pytest-forked>=1.0.2
-pytest-html>=1.21.1
+pytest-html==1.20.0
 pytest-metadata>=1.8.0
 pytest-ordering>=0.6
 pytest-rerunfailures>=7.0

--- a/seleniumbase/console_scripts/sb_mkdir.py
+++ b/seleniumbase/console_scripts/sb_mkdir.py
@@ -82,7 +82,7 @@ def main():
         data.append('        self.open("https://xkcd.com/353/")')
         data.append("        self.assert_element('img[alt=\"Python\"]')")
         data.append("        self.click('a[rel=\"license\"]')")
-        data.append('        self.assert_text("free to copy", "div center")')
+        data.append('        self.assert_text("free to copy and reuse")')
         data.append('        self.open("https://xkcd.com/1481/")')
         data.append(
             "        title = self.get_attribute(\"#comic img\", \"title\")")

--- a/seleniumbase/fixtures/js_utils.py
+++ b/seleniumbase/fixtures/js_utils.py
@@ -526,6 +526,8 @@ def post_messenger_error_message(driver, message, msg_dur):
 
 
 def highlight_with_js_2(driver, message, selector, o_bs, msg_dur):
+    if selector == "html":
+        selector = "body"
     script = ("""document.querySelector('%s').style =
               'box-shadow: 0px 0px 6px 6px rgba(128, 128, 128, 0.5)';"""
               % selector)
@@ -560,6 +562,8 @@ def highlight_with_js_2(driver, message, selector, o_bs, msg_dur):
 
 
 def highlight_with_jquery_2(driver, message, selector, o_bs, msg_dur):
+    if selector == "html":
+        selector = "body"
     script = """jQuery('%s').css('box-shadow',
         '0px 0px 6px 6px rgba(128, 128, 128, 0.5)');""" % selector
     safe_execute_script(driver, script)

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'pytest>=4.6.4',  # Keep at >=4.6.4 for Python 2 compatibility
         'pytest-cov>=2.7.1',
         'pytest-forked>=1.0.2',
-        'pytest-html>=1.21.1',
+        'pytest-html==1.20.0',  # Keep at 1.20.0 (later versions have errors)
         'pytest-metadata>=1.8.0',
         'pytest-ordering>=0.6',
         'pytest-rerunfailures>=7.0',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.25.2',
+    version='1.25.3',
     description='Reliable Browser Automation & Testing Framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fix pytest-html reports on Windows
* Use pytest-html==1.20.0 (later versions have errors on Windows)