### PR TITLE
Use shutil.move() instead of os.rename()

### DIFF
--- a/seleniumbase/utilities/selenium_grid/download_selenium_server.py
+++ b/seleniumbase/utilities/selenium_grid/download_selenium_server.py
@@ -1,6 +1,7 @@
 """ Downloads the Selenium Server JAR file and renames it. """
 
 import os
+import shutil
 import sys
 if sys.version_info[0] == 2:
     from urllib import urlopen
@@ -45,9 +46,9 @@ def main(force_download=True):
         for filename in os.listdir("."):
             # If multiple copies exist, keep only the latest and rename it.
             if filename.startswith("selenium-server-standalone-"):
-                os.rename(filename, RENAMED_JAR_FILE)
+                shutil.move(filename, RENAMED_JAR_FILE)
                 if FULL_DOWNLOAD_PATH != FULL_EXPECTED_PATH:
-                    os.rename(RENAMED_JAR_FILE, FULL_EXPECTED_PATH)
+                    shutil.move(RENAMED_JAR_FILE, FULL_EXPECTED_PATH)
         print("%s\n" % FULL_EXPECTED_PATH)
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except IOError:
 
 setup(
     name='seleniumbase',
-    version='1.28.1',
+    version='1.28.2',
     description='Fast, Easy, and Reliable Browser Automation & Testing.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Use shutil.move() instead of os.rename()
* This was used for downloading the selenium server and placing it in the correct directory