### PR TITLE
Change nosetest config filename resulting from mkdir cli utility

### DIFF
--- a/seleniumbase/console_scripts/sb_mkdir.py
+++ b/seleniumbase/console_scripts/sb_mkdir.py
@@ -78,7 +78,7 @@ def main():
         data.append("")
         data.append("[bdist_wheel]")
         data.append("universal=1")
-        file_path = "%s/%s" % (dir_name, "config.cfg")
+        file_path = "%s/%s" % (dir_name, "setup.cfg")
         file = codecs.open(file_path, "w+", "utf-8")
         file.writelines("\r\n".join(data))
         file.close()


### PR DESCRIPTION
I've never used nosetest, but from skimming their website and other directories in your repo, it looks like 'setup.cfg' is being used for configuring nosetest.