### PR TITLE
Add the ``--time-limit=s`` feature to fail long-running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img src="https://cdn2.hubspot.net/hubfs/100006/images/super_logo_sb20.png" title="SeleniumBase" height="48">](https://github.com/seleniumbase/SeleniumBase/blob/master/README.md)
+[<img src="https://cdn2.hubspot.net/hubfs/100006/images/super_logo_sb26.png" title="SeleniumBase" height="48">](https://github.com/seleniumbase/SeleniumBase/blob/master/README.md)
 
 [<img src="https://img.shields.io/github/release/seleniumbase/SeleniumBase.svg" alt=" " />](https://github.com/seleniumbase/SeleniumBase/releases) [<img src="https://img.shields.io/pypi/v/seleniumbase.svg" alt=" " />](https://pypi.python.org/pypi/seleniumbase) [<img src="https://badges.gitter.im/seleniumbase/SeleniumBase.svg" alt=" " />](https://gitter.im/seleniumbase/SeleniumBase) [<img src="https://img.shields.io/travis/seleniumbase/SeleniumBase/master.svg?logo=travis" alt=" " />](https://travis-ci.org/seleniumbase/SeleniumBase) [<img src="https://dev.azure.com/seleniumbase/seleniumbase/_apis/build/status/seleniumbase.SeleniumBase?branchName=master" alt=" " />](https://dev.azure.com/seleniumbase/seleniumbase/_build) [<img src="https://github.com/seleniumbase/SeleniumBase/workflows/CI%20build/badge.svg">](https://github.com/seleniumbase/SeleniumBase/actions) [<img src="https://img.shields.io/badge/license-MIT-22BBCC.svg" alt=" " />](https://github.com/seleniumbase/SeleniumBase/blob/master/LICENSE) [<img src="https://img.shields.io/github/stars/seleniumbase/seleniumbase.svg" alt=" " />](https://github.com/seleniumbase/SeleniumBase/stargazers)
 
@@ -229,6 +229,7 @@ SeleniumBase provides additional Pytest command-line options for tests:
 --headed  # (The option to run tests with a GUI on Linux OS.)
 --start-page=URL  # (The starting URL for the web browser when tests begin.)
 --archive-logs  # (Archive old log files instead of deleting them.)
+--time-limit  # (The option to set a time limit per test before failing it.)
 --slow  # (The option to slow down the automation.)
 --demo  # (The option to visually see test actions as they occur.)
 --demo-sleep=SECONDS  # (The option to wait longer after Demo Mode actions.)
@@ -662,4 +663,4 @@ Additionally, you can use the ``@retry_on_exception()`` decorator to specificall
 
 [<img src="https://cdn2.hubspot.net/hubfs/100006/images/sb_media_logo_c.png" title="SeleniumBase" height="100">](https://github.com/seleniumbase/SeleniumBase/blob/master/README.md) <br /> [<img src="https://img.shields.io/badge/license-MIT-22BBCC.svg" alt=" " />](https://github.com/seleniumbase/SeleniumBase/blob/master/LICENSE)
 
-[<img src="https://cdn2.hubspot.net/hubfs/100006/images/super_logo_n.png" title="SeleniumBase" height="48">](https://github.com/seleniumbase/SeleniumBase/blob/master/README.md)
+[<img src="https://cdn2.hubspot.net/hubfs/100006/images/super_logo_sb22.png" title="SeleniumBase" height="48">](https://github.com/seleniumbase/SeleniumBase/blob/master/README.md)

--- a/examples/ReadMe.md
+++ b/examples/ReadMe.md
@@ -109,4 +109,4 @@ python gui_test_runner.py
 
 --------
 
-[<img src="https://cdn2.hubspot.net/hubfs/100006/images/super_logo_n.png" title="SeleniumBase" height="48">](https://github.com/seleniumbase/SeleniumBase/blob/master/README.md)
+[<img src="https://cdn2.hubspot.net/hubfs/100006/images/super_logo_sb23.png" title="SeleniumBase" height="48">](https://github.com/seleniumbase/SeleniumBase/blob/master/README.md)

--- a/examples/raw_parameter_script.py
+++ b/examples/raw_parameter_script.py
@@ -56,6 +56,7 @@ except (ImportError, ValueError):
     sb.with_s3_logging = False
     sb.js_checking_on = False
     sb.is_pytest = False
+    sb.time_limit = None
     sb.slow_mode = False
     sb.demo_mode = False
     sb.demo_sleep = 1

--- a/examples/timeout_test.py
+++ b/examples/timeout_test.py
@@ -1,15 +1,15 @@
-""" This test fails on purpose to demonstrate the timeout feature
-    for tests that run longer than the time limit specified. """
+""" This test fails on purpose to demonstrate the time-limit feature
+    for tests that run longer than the time limit specified in seconds.
+    Usage: (inside tests) -> self.set_time_limit(SECONDS) """
 
 import pytest
-import time
 from seleniumbase import BaseCase
 
 
 class MyTestClass(BaseCase):
 
     @pytest.mark.expected_failure
-    @pytest.mark.timeout(6)  # The test will fail if it runs longer than this
-    def test_timeout_failure(self):
+    def test_time_limit_feature(self):
+        self.set_time_limit(6)  # Test fails if run-time exceeds limit
         self.open("https://xkcd.com/1658/")
-        time.sleep(7)
+        self.sleep(7)

--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -262,6 +262,8 @@ self.js_update_text(selector, new_value, by=By.CSS_SELECTOR, timeout=None)
 
 self.jquery_update_text(selector, new_value, by=By.CSS_SELECTOR, timeout=None)
 
+self.set_time_limit(time_limit)
+
 ########
 
 self.add_css_link(css_link)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ pytest-html==2.0.1;python_version>="3.6"
 pytest-metadata>=1.8.0
 pytest-ordering>=0.6
 pytest-rerunfailures>=8.0
-pytest-timeout>=1.3.4
 pytest-xdist>=1.31.0
 parameterized>=0.7.1
 soupsieve==1.9.5

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -601,7 +601,8 @@ def get_local_driver(
         else:
             return webdriver.Edge()
     elif browser_name == constants.Browser.SAFARI:
-        if ("-n" in sys.argv or "".join(sys.argv) == "-c"):
+        arg_join = " ".join(sys.argv)
+        if ("-n" in sys.argv) or ("-n=" in arg_join) or (arg_join == "-c"):
             # Skip if multithreaded
             raise Exception("Can't run Safari tests in multi-threaded mode!")
         return webdriver.Safari()

--- a/seleniumbase/core/log_helper.py
+++ b/seleniumbase/core/log_helper.py
@@ -121,7 +121,8 @@ def copytree(src, dst, symlinks=False, ignore=None):
 
 def archive_logs_if_set(log_path, archive_logs=False):
     """ Handle Logging """
-    if "-n" in sys.argv or "".join(sys.argv) == "-c":
+    arg_join = " ".join(sys.argv)
+    if ("-n" in sys.argv) or ("-n=" in arg_join) or (arg_join == "-c"):
         return  # Skip if multithreaded
     if log_path.endswith("/"):
         log_path = log_path[:-1]
@@ -172,7 +173,8 @@ def log_folder_setup(log_path, archive_logs=False):
             if not settings.ARCHIVE_EXISTING_LOGS and not archive_logs:
                 shutil.rmtree(archived_logs)
             else:
-                if ("-n" in sys.argv or "".join(sys.argv) == "-c"):
+                a_join = " ".join(sys.argv)
+                if ("-n" in sys.argv) or ("-n=" in a_join) or (a_join == "-c"):
                     # Logs are saved/archived now if tests are multithreaded
                     pass
                 else:

--- a/seleniumbase/core/tour_helper.py
+++ b/seleniumbase/core/tour_helper.py
@@ -11,8 +11,7 @@ from seleniumbase.core import style_sheet
 from seleniumbase.fixtures import constants
 from seleniumbase.fixtures import js_utils
 from seleniumbase.fixtures import page_actions
-
-EXPORTED_TOURS_FOLDER = "tours_exported"
+EXPORTED_TOURS_FOLDER = constants.Tours.EXPORTED_TOURS_FOLDER
 
 
 def activate_bootstrap(driver):

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -55,6 +55,7 @@ from seleniumbase.fixtures import constants
 from seleniumbase.fixtures import js_utils
 from seleniumbase.fixtures import page_actions
 from seleniumbase.fixtures import page_utils
+from seleniumbase.fixtures import shared_utils
 from seleniumbase.fixtures import xpath_to_css
 logging.getLogger("requests").setLevel(logging.ERROR)
 logging.getLogger("urllib3").setLevel(logging.ERROR)
@@ -1662,7 +1663,17 @@ class BaseCase(unittest.TestCase):
         js_utils.wait_for_angularjs(self.driver, timeout, **kwargs)
 
     def sleep(self, seconds):
-        time.sleep(seconds)
+        if not sb_config.time_limit:
+            time.sleep(seconds)
+        else:
+            start_ms = time.time() * 1000.0
+            stop_ms = start_ms + (seconds * 1000.0)
+            for x in range(int(seconds * 5)):
+                shared_utils.check_if_time_limit_exceeded()
+                now_ms = time.time() * 1000.0
+                if now_ms >= stop_ms:
+                    break
+                time.sleep(0.2)
 
     def activate_jquery(self):
         """ If "jQuery is not defined", use this method to activate it for use.
@@ -2456,6 +2467,22 @@ class BaseCase(unittest.TestCase):
             element.send_keys('\n')
         self.__demo_mode_pause_if_active()
 
+    def set_time_limit(self, time_limit):
+        if time_limit:
+            try:
+                sb_config.time_limit = float(time_limit)
+            except Exception:
+                sb_config.time_limit = None
+        else:
+            sb_config.time_limit = None
+        if sb_config.time_limit and sb_config.time_limit > 0:
+            sb_config.time_limit_ms = int(sb_config.time_limit * 1000.0)
+            self.time_limit = sb_config.time_limit
+        else:
+            self.time_limit = None
+            sb_config.time_limit = None
+            sb_config.time_limit_ms = None
+
     ############
 
     def add_css_link(self, css_link):
@@ -3238,6 +3265,7 @@ class BaseCase(unittest.TestCase):
         start_ms = time.time() * 1000.0
         stop_ms = start_ms + (timeout * 1000.0)
         for x in range(int(timeout * 5)):
+            shared_utils.check_if_time_limit_exceeded()
             try:
                 if not self.is_link_text_present(link_text):
                     raise Exception(
@@ -3258,6 +3286,7 @@ class BaseCase(unittest.TestCase):
         start_ms = time.time() * 1000.0
         stop_ms = start_ms + (timeout * 1000.0)
         for x in range(int(timeout * 5)):
+            shared_utils.check_if_time_limit_exceeded()
             try:
                 if not self.is_partial_link_text_present(link_text):
                     raise Exception(
@@ -4146,6 +4175,7 @@ class BaseCase(unittest.TestCase):
             self.demo_mode = sb_config.demo_mode
             self.demo_sleep = sb_config.demo_sleep
             self.highlights = sb_config.highlights
+            self.time_limit = sb_config.time_limit
             self.environment = sb_config.environment
             self.env = self.environment  # Add a shortened version
             self.with_selenium = sb_config.with_selenium  # Should be True
@@ -4243,6 +4273,9 @@ class BaseCase(unittest.TestCase):
                     # pyvirtualdisplay might not be necessary anymore because
                     # Chrome and Firefox now have built-in headless displays
                     pass
+        else:
+            # (Nosetests / Not Pytest)
+            pass  # Setup performed in plugins
 
         # Verify that SeleniumBase is installed successfully
         if not hasattr(self, "browser"):
@@ -4250,8 +4283,17 @@ class BaseCase(unittest.TestCase):
                             """*** Please REINSTALL SeleniumBase using: >\n"""
                             """    >>> "pip install -r requirements.txt"\n"""
                             """    >>> "python setup.py install" """)
+
+        # Configure the test time limit (if used)
+        self.set_time_limit(self.time_limit)
+
+        # Set the start time for the test (in ms)
+        sb_config.start_time_ms = int(time.time() * 1000.0)
+
+        # Parse the settings file
         if self.settings_file:
             settings_parser.set_settings(self.settings_file)
+
         # Mobile Emulator device metrics: CSS Width, CSS Height, & Pixel-Ratio
         if self.device_metrics:
             metrics_string = self.device_metrics

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -976,14 +976,15 @@ class BaseCase(unittest.TestCase):
     def click_visible_elements(self, selector, by=By.CSS_SELECTOR, limit=0):
         """ Finds all matching page elements and clicks visible ones in order.
             If a click reloads or opens a new page, the clicking will stop.
+            If no matching elements appear, an Exception will be raised.
+            If "limit" is set and > 0, will only click that many elements.
+            Also clicks elements that become visible from previous clicks.
             Works best for actions such as clicking all checkboxes on a page.
-            Example:  self.click_visible_elements('input[type="checkbox"]')
-            If "limit" is set and > 0, will only click that many elements. """
-        elements = []
-        try:
-            elements = self.find_visible_elements(selector, by=by)
-        except Exception:
-            elements = self.find_elements(selector, by=by)
+            Example:  self.click_visible_elements('input[type="checkbox"]') """
+        selector, by = self.__recalculate_selector(selector, by)
+        self.wait_for_element_present(
+            selector, by=by, timeout=settings.SMALL_TIMEOUT)
+        elements = self.find_elements(selector, by=by)
         click_count = 0
         for element in elements:
             if limit and limit > 0 and click_count >= limit:

--- a/seleniumbase/fixtures/constants.py
+++ b/seleniumbase/fixtures/constants.py
@@ -23,6 +23,10 @@ class SavedCookies:
     STORAGE_FOLDER = "saved_cookies"
 
 
+class Tours:
+    EXPORTED_TOURS_FOLDER = "tours_exported"
+
+
 class VisualBaseline:
     STORAGE_FOLDER = "visual_baseline"
 

--- a/seleniumbase/fixtures/js_utils.py
+++ b/seleniumbase/fixtures/js_utils.py
@@ -10,6 +10,7 @@ from seleniumbase.common import decorators
 from seleniumbase.config import settings
 from seleniumbase.core import style_sheet
 from seleniumbase.fixtures import constants
+from seleniumbase.fixtures import shared_utils
 
 
 def wait_for_ready_state_complete(driver, timeout=settings.EXTREME_TIMEOUT):
@@ -19,10 +20,10 @@ def wait_for_ready_state_complete(driver, timeout=settings.EXTREME_TIMEOUT):
     fully loaded (although AJAX and other loads might still be happening).
     This method will wait until document.readyState == "complete".
     """
-
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
+        shared_utils.check_if_time_limit_exceeded()
         try:
             ready_state = driver.execute_script("return document.readyState")
         except WebDriverException:

--- a/seleniumbase/fixtures/page_actions.py
+++ b/seleniumbase/fixtures/page_actions.py
@@ -36,6 +36,7 @@ from selenium.webdriver.remote.errorhandler import NoSuchWindowException
 from seleniumbase.config import settings
 from seleniumbase.core import log_helper
 from seleniumbase.fixtures import page_utils
+from seleniumbase.fixtures import shared_utils
 ENI_Exception = selenium_exceptions.ElementNotInteractableException
 
 
@@ -215,6 +216,7 @@ def wait_for_element_present(driver, selector, by=By.CSS_SELECTOR,
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
+        shared_utils.check_if_time_limit_exceeded()
         try:
             element = driver.find_element(by=by, value=selector)
             return element
@@ -249,6 +251,7 @@ def wait_for_element_visible(driver, selector, by=By.CSS_SELECTOR,
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
+        shared_utils.check_if_time_limit_exceeded()
         try:
             element = driver.find_element(by=by, value=selector)
             if element.is_displayed():
@@ -294,6 +297,7 @@ def wait_for_text_visible(driver, text, selector, by=By.CSS_SELECTOR,
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
+        shared_utils.check_if_time_limit_exceeded()
         try:
             element = driver.find_element(by=by, value=selector)
             if element.is_displayed() and text in element.text:
@@ -336,6 +340,7 @@ def wait_for_exact_text_visible(driver, text, selector, by=By.CSS_SELECTOR,
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
+        shared_utils.check_if_time_limit_exceeded()
         try:
             element = driver.find_element(by=by, value=selector)
             if element.is_displayed() and text.strip() == element.text.strip():
@@ -372,6 +377,7 @@ def wait_for_element_absent(driver, selector, by=By.CSS_SELECTOR,
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
+        shared_utils.check_if_time_limit_exceeded()
         try:
             driver.find_element(by=by, value=selector)
             now_ms = time.time() * 1000.0
@@ -402,6 +408,7 @@ def wait_for_element_not_visible(driver, selector, by=By.CSS_SELECTOR,
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
+        shared_utils.check_if_time_limit_exceeded()
         try:
             element = driver.find_element(by=by, value=selector)
             if element.is_displayed():
@@ -439,6 +446,7 @@ def wait_for_text_not_visible(driver, text, selector, by=By.CSS_SELECTOR,
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
+        shared_utils.check_if_time_limit_exceeded()
         if not is_text_visible(driver, text, selector, by=by):
             return True
         now_ms = time.time() * 1000.0
@@ -603,6 +611,7 @@ def wait_for_and_switch_to_alert(driver, timeout=settings.LARGE_TIMEOUT):
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
+        shared_utils.check_if_time_limit_exceeded()
         try:
             alert = driver.switch_to.alert
             # Raises exception if no alert present
@@ -628,6 +637,7 @@ def switch_to_frame(driver, frame, timeout=settings.SMALL_TIMEOUT):
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
+        shared_utils.check_if_time_limit_exceeded()
         try:
             driver.switch_to.frame(frame)
             return True
@@ -665,6 +675,7 @@ def switch_to_window(driver, window, timeout=settings.SMALL_TIMEOUT):
     stop_ms = start_ms + (timeout * 1000.0)
     if isinstance(window, int):
         for x in range(int(timeout * 10)):
+            shared_utils.check_if_time_limit_exceeded()
             try:
                 window_handle = driver.window_handles[window]
                 driver.switch_to.window(window_handle)
@@ -678,6 +689,7 @@ def switch_to_window(driver, window, timeout=settings.SMALL_TIMEOUT):
     else:
         window_handle = window
         for x in range(int(timeout * 10)):
+            shared_utils.check_if_time_limit_exceeded()
             try:
                 driver.switch_to.window(window_handle)
                 return True

--- a/seleniumbase/fixtures/shared_utils.py
+++ b/seleniumbase/fixtures/shared_utils.py
@@ -1,0 +1,21 @@
+"""
+This module contains shared utility methods.
+"""
+import time
+from seleniumbase import config as sb_config
+
+
+def check_if_time_limit_exceeded():
+    if sb_config.time_limit:
+        time_limit = sb_config.time_limit
+        now_ms = int(time.time() * 1000)
+        if now_ms > sb_config.start_time_ms + sb_config.time_limit_ms:
+            display_time_limit = time_limit
+            plural = "s"
+            if float(int(time_limit)) == float(time_limit):
+                display_time_limit = int(time_limit)
+                if display_time_limit == 1:
+                    plural = ""
+            raise Exception(
+                "This test has exceeded the time limit of %s second%s!"
+                "" % (display_time_limit, plural))

--- a/seleniumbase/plugins/base_plugin.py
+++ b/seleniumbase/plugins/base_plugin.py
@@ -77,15 +77,28 @@ class Base(Plugin):
             default=False,
             help="If true when using report, will display it after tests run.")
         found_processes_arg = False
+        found_timeout_arg = False
         for arg in sys.argv:
             if "--processes=" in arg:
                 found_processes_arg = True
+            if "--timeout=" in arg:
+                found_timeout_arg = True
         if found_processes_arg:
             print("* WARNING: Don't use multi-threading with nosetests! *")
             parser.add_option(
-                '--processes', dest='processes',
+                '--processes',
+                dest='processes',
                 default=0,
                 help="WARNING: Don't use multi-threading with nosetests!")
+        if found_timeout_arg:
+            print("\n  WARNING: Don't use --timeout=s from pytest-timeout!")
+            print("  It's not thread-safe for WebDriver processes!")
+            print("  Use --time-limit=s from SeleniumBase instead!\n")
+            parser.add_option(
+                '--timeout',
+                dest='timeout',
+                default=0,
+                help="Don't use --timeout=s! Use --time-limit=s instead!")
 
     def configure(self, options, conf):
         super(Base, self).configure(options, conf)

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -30,6 +30,7 @@ def pytest_addoption(parser):
     --headed  (The option to run tests with a GUI on Linux OS.)
     --start-page=URL  (The starting URL for the web browser when tests begin.)
     --archive-logs  (Archive old log files instead of deleting them.)
+    --time-limit  (The option to set a time limit per test before failing it.)
     --slow  (The option to slow down the automation.)
     --demo  (The option to visually see test actions as they occur.)
     --demo-sleep=SECONDS  (The option to wait longer after Demo Mode actions.)
@@ -247,6 +248,12 @@ def pytest_addoption(parser):
                      default=True,
                      help="""This is used by the BaseCase class to tell apart
                           pytest runs from nosetest runs. (Automatic)""")
+    parser.addoption('--time_limit', '--time-limit', '--timelimit',
+                     action='store',
+                     dest='time_limit',
+                     default=None,
+                     help="""Use this to set a time limit per test, in seconds.
+                          If a test runs beyond the limit, it fails.""")
     parser.addoption('--slow_mode', '--slow-mode', '--slow',
                      action="store_true",
                      dest='slow_mode',
@@ -387,6 +394,7 @@ def pytest_configure(config):
     sb_config.database_env = config.getoption('database_env')
     sb_config.log_path = 'latest_logs/'  # (No longer editable!)
     sb_config.archive_logs = config.getoption('archive_logs')
+    sb_config.time_limit = config.getoption('time_limit')
     sb_config.slow_mode = config.getoption('slow_mode')
     sb_config.demo_mode = config.getoption('demo_mode')
     sb_config.demo_sleep = config.getoption('demo_sleep')

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -407,7 +407,8 @@ def pytest_configure(config):
     sb_config.pytest_html_report = config.getoption('htmlpath')  # --html=FILE
 
     if sb_config.reuse_session:
-        if "-n" in sys.argv or "".join(sys.argv) == "-c":
+        arg_join = " ".join(sys.argv)
+        if ("-n" in sys.argv) or ("-n=" in arg_join) or (arg_join == "-c"):
             # Can't "reuse_session" if multithreaded
             sb_config.reuse_session = False
 

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -349,6 +349,12 @@ def pytest_addoption(parser):
                      help="""Setting this overrides the default timeout
                           by the multiplier when waiting for page elements.
                           Unused when tests overide the default value.""")
+    for arg in sys.argv:
+        if "--timeout=" in arg:
+            raise Exception(
+                "\n\n  Don't use --timeout=s from pytest-timeout! "
+                "\n  It's not thread-safe for WebDriver processes! "
+                "\n  Use --time-limit=s from SeleniumBase instead!\n")
 
 
 def pytest_configure(config):

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -24,6 +24,7 @@ class SeleniumBrowser(Plugin):
     --headless  (The option to run tests headlessly. The default on Linux OS.)
     --headed  (The option to run tests with a GUI on Linux OS.)
     --start-page=URL  (The starting URL for the web browser when tests begin.)
+    --time-limit  (The option to set a time limit per test before failing it.)
     --slow  (The option to slow down the automation.)
     --demo  (The option to visually see test actions as they occur.)
     --demo-sleep=SECONDS  (The option to wait longer after Demo Mode actions.)
@@ -168,6 +169,13 @@ class SeleniumBrowser(Plugin):
                     when each test begins.
                     Default: None.""")
         parser.add_option(
+            '--time_limit', '--time-limit', '--timelimit',
+            action='store',
+            dest='time_limit',
+            default=None,
+            help="""Use this to set a time limit per test, in seconds.
+                    If a test runs beyond the limit, it fails.""")
+        parser.add_option(
             '--slow_mode', '--slow-mode', '--slow',
             action="store_true",
             dest='slow_mode',
@@ -300,6 +308,7 @@ class SeleniumBrowser(Plugin):
         test.test.user_agent = self.options.user_agent
         test.test.mobile_emulator = self.options.mobile_emulator
         test.test.device_metrics = self.options.device_metrics
+        test.test.time_limit = self.options.time_limit
         test.test.slow_mode = self.options.slow_mode
         test.test.demo_mode = self.options.demo_mode
         test.test.demo_sleep = self.options.demo_sleep

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.34.18',
+    version='1.34.19',
     description='Fast, Easy, and Reliable Browser Automation & Testing.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,6 @@ setup(
         'pytest-metadata>=1.8.0',
         'pytest-ordering>=0.6',
         'pytest-rerunfailures>=8.0',
-        'pytest-timeout>=1.3.4',
         'pytest-xdist>=1.31.0',
         'parameterized>=0.7.1',
         'soupsieve==1.9.5',


### PR DESCRIPTION
### Add ``--time-limit=s`` to fail long-running tests
* This removes and replaces pytest-timeout, which wasn't thread-safe

Usage (command-line):
``--time-limit=s``  (fail the tests that run longer than "s" seconds)

Usage (in-test):
``self.set_time_limit(s)``  (fail that test if it runs longer than "s" seconds)

#### Other unrelated changes:
* Better detection of multi-thread use
* Update click_visible_elements()
* Some minor refactoring
