### PR TITLE
Allow URLS that start with "://" for open()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img src="https://cdn2.hubspot.net/hubfs/100006/images/super_logo_e.png" title="SeleniumBase" height="48">](https://github.com/seleniumbase/SeleniumBase/blob/master/README.md)<br />
+[<img src="https://cdn2.hubspot.net/hubfs/100006/fancy_logo_6.png" title="SeleniumBase" align="center" height="38">](https://github.com/seleniumbase/SeleniumBase/blob/master/README.md)<br />
 
 [<img src="https://img.shields.io/github/release/seleniumbase/SeleniumBase.svg?color=2277EE" alt="SeleniumBase" />](https://github.com/seleniumbase/SeleniumBase/releases) [<img src="https://img.shields.io/pypi/v/seleniumbase.svg?color=22AAEE" alt=" " />](https://pypi.python.org/pypi/seleniumbase) [<img src="https://badges.gitter.im/seleniumbase/SeleniumBase.svg" alt=" " />](https://gitter.im/seleniumbase/SeleniumBase) [<img src="https://img.shields.io/travis/seleniumbase/SeleniumBase/master.svg" alt=" " />](https://travis-ci.org/seleniumbase/SeleniumBase) [<img src="https://github.com/seleniumbase/SeleniumBase/workflows/CI%20build/badge.svg">](https://github.com/seleniumbase/SeleniumBase/actions)<br />
 

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -95,6 +95,9 @@ class BaseCase(unittest.TestCase):
     def open(self, url):
         """ Navigates the current browser window to the specified page. """
         self.__last_page_load_url = None
+        if url.startswith("://"):
+            # Convert URLs such as "://google.com" into "https://google.com"
+            url = "https" + url
         self.driver.get(url)
         if settings.WAIT_FOR_RSC_ON_PAGE_LOADS:
             self.wait_for_ready_state_complete()

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.35.0',
+    version='1.35.1',
     description='Fast, Easy, and Reliable Browser Automation & Testing.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This fixes https://github.com/seleniumbase/SeleniumBase/issues/494
Allow URLS that start with ``://`` for the ``open(URL)`` method

If you copy/paste a URL such as ``://google.com`` into a web browser, the browser automatically converts the URL to ``https://google.com``. But if you use the webdriver ``get(URL)`` method for URLs that start with ``://``, you'll get the following error:
```
selenium.common.exceptions.WebDriverException:
Message: unhandled inspector error:
{"code":-32000,"message":"Cannot navigate to invalid URL"}
```
To fix this, we'll make sure that the SeleniumBase ``open(URL)`` method (which wraps ``driver.get``) automatically adds the ``https`` to URLs that start with ``://`` to prevent the error.
As a bonus, you'll be able to make your Python code lines 5 characters shorter if they use the ``open(URL)`` method for ``https`` URLs.
