### PR TITLE
Fix MSEdgeDriver automatic installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pytest-ordering==0.6
 pytest-rerunfailures==8.0;python_version<"3.6"
 pytest-rerunfailures==9.0;python_version>="3.6"
 pytest-xdist==1.31.0
-parameterized==0.7.3
+parameterized==0.7.4
 soupsieve==1.9.5;python_version<"3.5"
 soupsieve==2.0;python_version>="3.5"
 beautifulsoup4==4.9.0

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -613,7 +613,7 @@ def get_local_driver(
                     # (Not multithreaded)
                     from seleniumbase.console_scripts import sb_install
                     sys_args = sys.argv  # Save a copy of current sys args
-                    print("\nWarning: chromedriver not found. Installing now:")
+                    print("\nWarning: msedgedriver not found. Installing now:")
                     sb_install.main(override="edgedriver")
                     sys.argv = sys_args  # Put back the original sys args
             return webdriver.Chrome(executable_path=LOCAL_EDGEDRIVER,

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -83,11 +83,7 @@ def is_chromedriver_on_path():
 
 
 def is_edgedriver_on_path():
-    paths = os.environ["PATH"].split(os.pathsep)
-    for path in paths:
-        if os.path.exists(path + '/' + "msedgedriver"):
-            return True
-    return False
+    return os.path.exists(LOCAL_EDGEDRIVER)
 
 
 def is_geckodriver_on_path():

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
         'pytest-rerunfailures==8.0;python_version<"3.6"',
         'pytest-rerunfailures==9.0;python_version>="3.6"',
         'pytest-xdist==1.31.0',
-        'parameterized==0.7.3',
+        'parameterized==0.7.4',
         'soupsieve==1.9.5;python_version<"3.5"',
         'soupsieve==2.0;python_version>="3.5"',
         'beautifulsoup4==4.9.0',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.37.1',
+    version='1.37.2',
     description='Fast, Easy, and Reliable Browser Automation & Testing.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Fix MSEdgeDriver automatic installation
* The MSEdgeDriver being using must be on the local SeleniumBase Path rather than on the System Path. This prevents permission issues. If it's not there when a test uses the Edge Browser, it will automatically get downloaded into the SeleniumBase drivers folder.

Here's an example of running a SeleniumBase test using the new Edge browser:
```bash
cd examples/
pytest basic_test.py -v --browser=edge
=============================================== test session starts ================================================
platform darwin -- Python 3.7.0, pytest-5.3.5, py-1.8.0, pluggy-0.13.1 -- /Users/michael/.virtualenvs/sbase7/bin/python
metadata: {'Python': '3.7.0', 'Platform': 'Darwin-18.7.0-x86_64-i386-64bit', 'Packages': {'pytest': '5.3.5', 'py': '1.8.0', 'pluggy': '0.13.1'}, 'Plugins': {'timeout': '1.3.4', 'html': '2.0.1', 'rerunfailures': '9.0', 'xdist': '1.31.0', 'ordering': '0.6', 'forked': '1.1.3', 'metadata': '1.8.0', 'cov': '2.8.1', 'seleniumbase': '1.37.2'}}
rootdir: /Users/michael/github/SeleniumBase, inifile: pytest.ini
plugins: timeout-1.3.4, html-2.0.1, rerunfailures-9.0, xdist-1.31.0, ordering-0.6, forked-1.1.3, metadata-1.8.0, cov-2.8.1, seleniumbase-1.37.2
collected 1 item                                                                                                   

basic_test.py::MyTestClass::test_basic 
Warning: msedgedriver not found. Installing now:

Downloading edgedriver_mac64.zip from:
https://msedgedriver.azureedge.net/79.0.309.65/edgedriver_mac64.zip ...
Download Complete!

Extracting ['msedgedriver'] from edgedriver_mac64.zip ...
Unzip Complete!

The file [msedgedriver] was saved to:
/Users/michael/github/SeleniumBase/seleniumbase/drivers/msedgedriver

Making [msedgedriver 79.0.309.65] executable ...
[msedgedriver] is now ready for use!

PASSED

================================================ 1 passed in 11.58s
```