### PR TITLE
Updates to running WebDriver tests with Safari

### DIFF
--- a/examples/test_apple_site.py
+++ b/examples/test_apple_site.py
@@ -1,0 +1,23 @@
+from seleniumbase import BaseCase
+
+
+class AppleTestClass(BaseCase):
+
+    def test_apple_developer_site_webdriver_instructions(self):
+        self.demo_mode = True
+        self.demo_sleep = 0.5
+        self.message_duration = 2.0
+        self.open("https://developer.apple.com/search/")
+        page = "Testing with WebDriver in Safari"
+        self.update_text('[placeholder*="developer.apple.com"]', page + "\n")
+        self.click("link=Testing with WebDriver in Safari")
+        self.assert_element('[href="/documentation"]')
+        self.assert_text("Testing with WebDriver in Safari", "h1")
+        self.highlight("div.topic-description p")
+        self.highlight("h2")
+        h3 = "h3:nth-of-type(%s)"
+        self.assert_text("Make Sure You Have Safari’s WebDriver", h3 % "1")
+        self.assert_text("Get the Correct Selenium Library", h3 % "2")
+        self.assert_text("Configure Safari to Enable WebDriver", h3 % "3")
+        self.assert_text("Write a WebDriver Testing Suite", h3 % "4")
+        self.assert_text("Run Your Test", h3 % "5")

--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -138,6 +138,8 @@ self.execute_async_script(script, timeout=None)
 
 self.safe_execute_script(script)
 
+self.set_window_rect(x, y, width, height)
+
 self.set_window_size(width, height)
 
 self.maximize_window()

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ soupsieve==1.9.5;python_version<"3.5"
 soupsieve==2.0;python_version>="3.5"
 beautifulsoup4==4.9.0
 atomicwrites==1.3.0
-cryptography==2.9
+cryptography==2.9.2
 pyopenssl==19.1.0
 pygments==2.5.2;python_version<"3.5"
 pygments==2.6.1;python_version>="3.5"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -241,6 +241,13 @@ def _set_chrome_options(
     return chrome_options
 
 
+def _set_safari_capabilities():
+    from selenium.webdriver.safari.webdriver import DesiredCapabilities as SDC
+    safari_capabilities = SDC.SAFARI.copy()
+    safari_capabilities["cleanSession"] = True
+    return safari_capabilities
+
+
 def _create_firefox_profile(
         downloads_path, proxy_string, user_agent, disable_csp):
     profile = webdriver.FirefoxProfile()
@@ -674,7 +681,8 @@ def get_local_driver(
         if ("-n" in sys.argv) or ("-n=" in arg_join) or (arg_join == "-c"):
             # Skip if multithreaded
             raise Exception("Can't run Safari tests in multi-threaded mode!")
-        return webdriver.Safari()
+        safari_capabilities = _set_safari_capabilities()
+        return webdriver.Safari(desired_capabilities=safari_capabilities)
     elif browser_name == constants.Browser.OPERA:
         if LOCAL_OPERADRIVER and os.path.exists(LOCAL_OPERADRIVER):
             try:

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -1674,7 +1674,7 @@ class BaseCase(unittest.TestCase):
                 width = settings.HEADLESS_START_WIDTH
                 height = settings.HEADLESS_START_HEIGHT
                 try:
-                    self.set_window_size(width, height)
+                    self.driver.set_window_size(width, height)
                     self.wait_for_ready_state_complete()
                 except Exception:
                     # This shouldn't fail, but in case it does,

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -1473,6 +1473,10 @@ class BaseCase(unittest.TestCase):
             self.activate_jquery()  # It's a good thing we can define it here
             self.execute_script(script)
 
+    def set_window_rect(self, x, y, width, height):
+        self.driver.set_window_rect(x, y, width, height)
+        self.__demo_mode_pause_if_active()
+
     def set_window_size(self, width, height):
         self.driver.set_window_size(width, height)
         self.__demo_mode_pause_if_active()

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -1702,6 +1702,11 @@ class BaseCase(unittest.TestCase):
                             self.wait_for_ready_state_complete()
                         except Exception:
                             pass  # Keep existing browser resolution
+                    else:
+                        try:
+                            self.driver.set_window_rect(10, 30, 945, 630)
+                        except Exception:
+                            pass
             if self.start_page and len(self.start_page) >= 4:
                 if page_utils.is_valid_url(self.start_page):
                     self.open(self.start_page)

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -216,7 +216,8 @@ def pytest_addoption(parser):
                                   username:password@servername:port  OR
                                   A dict key from proxy_list.PROXY_LIST
                           Default: None.""")
-    parser.addoption('--agent', action='store',
+    parser.addoption('--agent', '--user-agent', '--user_agent',
+                     action='store',
                      dest='user_agent',
                      default=None,
                      help="""Designates the User-Agent for the browser to use.

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -119,7 +119,7 @@ class SeleniumBrowser(Plugin):
                             A dict key from proxy_list.PROXY_LIST
                     Default: None.""")
         parser.add_option(
-            '--agent',
+            '--agent', '--user-agent', '--user_agent',
             action='store',
             dest='user_agent',
             default=None,

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.37.8',
+    version='1.37.9',
     description='Fast, Easy, and Reliable Browser Automation & Testing.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
         'soupsieve==2.0;python_version>="3.5"',
         'beautifulsoup4==4.9.0',
         'atomicwrites==1.3.0',
-        'cryptography==2.9',
+        'cryptography==2.9.2',
         'pyopenssl==19.1.0',
         'pygments==2.5.2;python_version<"3.5"',
         'pygments==2.6.1;python_version>="3.5"',


### PR DESCRIPTION
### Updates to running WebDriver tests with Safari
* Update Safari WebDriver launcher
* Set default Safari position and dimensions if not maximized
* Add an example test for the Apple developer site WebDriver instructions
* Add a localized ``set_window_rect(x, y, width, height)``
* Add additional ways to set the web browser's user agent
* Refresh Python dependencies