### PR TITLE
Add option to delete all cookies between tests that reuse sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ SeleniumBase provides additional Pytest command-line options for tests:
 --guest  # (The option to enable Chrome's Guest mode.)
 --devtools  # (The option to open Chrome's DevTools when the browser opens.)
 --reuse-session  # (The option to reuse the browser session between tests.)
+--crumbs  # (Option to delete all cookies between tests reusing a session.)
 --maximize-window  # (The option to start with the web browser maximized.)
 --save-screenshot  # (The option to save a screenshot after each test.)
 --visual-baseline  # (Set the visual baseline for Visual/Layout tests.)

--- a/README.md
+++ b/README.md
@@ -243,8 +243,6 @@ SeleniumBase provides additional Pytest command-line options for tests:
 --disable-csp  # (This disables the Content Security Policy of websites.)
 --enable-sync  # (The option to enable "Chrome Sync".)
 --use-auto-ext  # (The option to use Chrome's automation extension.)
---no-sandbox  # (The option to enable Chrome's "No-Sandbox" feature.)
---disable-gpu  # (The option to enable Chrome's "Disable GPU" feature.)
 --incognito  #  (The option to enable Chrome's Incognito mode.)
 --guest  # (The option to enable Chrome's Guest mode.)
 --devtools  # (The option to open Chrome's DevTools when the browser opens.)

--- a/examples/raw_parameter_script.py
+++ b/examples/raw_parameter_script.py
@@ -51,6 +51,7 @@ except (ImportError, ValueError):
     sb.no_sandbox = False
     sb.disable_gpu = False
     sb._reuse_session = False
+    sb._crumbs = False
     sb.visual_baseline = False
     sb.maximize_option = False
     sb.save_screenshot_after_test = False

--- a/help_docs/customizing_test_runs.md
+++ b/help_docs/customizing_test_runs.md
@@ -116,8 +116,6 @@ SeleniumBase provides additional Pytest command-line options for tests:
 --disable-csp  # (This disables the Content Security Policy of websites.)
 --enable-sync  # (The option to enable "Chrome Sync".)
 --use-auto-ext  # (The option to use Chrome's automation extension.)
---no-sandbox  # (The option to enable Chrome's "No-Sandbox" feature.)
---disable-gpu  # (The option to enable Chrome's "Disable GPU" feature.)
 --incognito  #  (The option to enable Chrome's Incognito mode.)
 --guest  # (The option to enable Chrome's Guest mode.)
 --devtools  # (The option to open Chrome's DevTools when the browser opens.)

--- a/help_docs/customizing_test_runs.md
+++ b/help_docs/customizing_test_runs.md
@@ -122,6 +122,7 @@ SeleniumBase provides additional Pytest command-line options for tests:
 --guest  # (The option to enable Chrome's Guest mode.)
 --devtools  # (The option to open Chrome's DevTools when the browser opens.)
 --reuse-session  # (The option to reuse the browser session between tests.)
+--crumbs  # (Option to delete all cookies between tests reusing a session.)
 --maximize-window  # (The option to start with the web browser maximized.)
 --save-screenshot  # (The option to save a screenshot after each test.)
 --visual-baseline  # (Set the visual baseline for Visual/Layout tests.)

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -4651,6 +4651,7 @@ class BaseCase(unittest.TestCase):
             self.extension_dir = sb_config.extension_dir
             self.maximize_option = sb_config.maximize_option
             self._reuse_session = sb_config.reuse_session
+            self._crumbs = sb_config.crumbs
             self.save_screenshot_after_test = sb_config.save_screenshot
             self.visual_baseline = sb_config.visual_baseline
             self.timeout_multiplier = sb_config.timeout_multiplier
@@ -4773,6 +4774,8 @@ class BaseCase(unittest.TestCase):
                     url = self.get_current_url()
                     if len(url) > 3:
                         has_url = True
+                    if self._crumbs:
+                        self.driver.delete_all_cookies()
                 except Exception:
                     pass
         if self._reuse_session and sb_config.shared_driver and has_url:

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -46,8 +46,6 @@ def pytest_addoption(parser):
     --disable-csp  (This disables the Content Security Policy of websites.)
     --enable-sync  (The option to enable "Chrome Sync".)
     --use-auto-ext  (The option to use Chrome's automation extension.)
-    --no-sandbox  (The option to enable Chrome's "No-Sandbox" feature.)
-    --disable-gpu  (The option to enable Chrome's "Disable GPU" feature.)
     --incognito  (The option to enable Chrome's Incognito mode.)
     --guest  (The option to enable Chrome's Guest mode.)
     --devtools  (The option to open Chrome's DevTools when the browser opens.)
@@ -364,12 +362,14 @@ def pytest_addoption(parser):
                      action="store_true",
                      dest='no_sandbox',
                      default=False,
-                     help="""Using this enables the "No Sandbox" feature.""")
+                     help="""Using this enables the "No Sandbox" feature.
+                          (This setting is now always enabled by default.)""")
     parser.addoption('--disable_gpu', '--disable-gpu',
                      action="store_true",
                      dest='disable_gpu',
                      default=False,
-                     help="""Using this enables the "Disable GPU" feature.""")
+                     help="""Using this enables the "Disable GPU" feature.
+                          (This setting is now always enabled by default.)""")
     parser.addoption('--incognito', '--incognito_mode', '--incognito-mode',
                      action="store_true",
                      dest='incognito',

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -52,6 +52,7 @@ def pytest_addoption(parser):
     --guest  (The option to enable Chrome's Guest mode.)
     --devtools  (The option to open Chrome's DevTools when the browser opens.)
     --reuse-session  (The option to reuse the browser session between tests.)
+    --crumbs  (Option to delete all cookies between tests reusing a session.)
     --maximize  (The option to start with the web browser maximized.)
     --save-screenshot  (The option to save a screenshot after each test.)
     --visual-baseline  (Set the visual baseline for Visual/Layout tests.)
@@ -390,6 +391,13 @@ def pytest_addoption(parser):
                      default=False,
                      help="""The option to reuse the selenium browser window
                           session between tests.""")
+    parser.addoption('--crumbs',
+                     action="store_true",
+                     dest='crumbs',
+                     default=False,
+                     help="""The option to delete all cookies between tests
+                          that reuse the same browser session. This option
+                          is only needed when using "--reuse-session".""")
     parser.addoption('--maximize_window', '--maximize-window', '--maximize',
                      '--fullscreen',
                      action="store_true",
@@ -478,6 +486,7 @@ def pytest_configure(config):
     sb_config.guest_mode = config.getoption('guest_mode')
     sb_config.devtools = config.getoption('devtools')
     sb_config.reuse_session = config.getoption('reuse_session')
+    sb_config.crumbs = config.getoption('crumbs')
     sb_config.shared_driver = None  # The default driver for session reuse
     sb_config.maximize_option = config.getoption('maximize_option')
     sb_config.save_screenshot = config.getoption('save_screenshot')

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -37,8 +37,6 @@ class SeleniumBrowser(Plugin):
     --disable-csp  (This disables the Content Security Policy of websites.)
     --enable-sync  (The option to enable "Chrome Sync".)
     --use-auto-ext  (The option to use Chrome's automation extension.)
-    --no-sandbox  (The option to enable Chrome's "No-Sandbox" feature.)
-    --disable-gpu  (The option to enable Chrome's "Disable GPU" feature.)
     --incognito  (The option to enable Chrome's Incognito mode.)
     --guest  (The option to enable Chrome's Guest mode.)
     --devtools  (The option to open Chrome's DevTools when the browser opens.)
@@ -279,13 +277,15 @@ class SeleniumBrowser(Plugin):
             action="store_true",
             dest='no_sandbox',
             default=False,
-            help="""Using this enables the "No Sandbox" feature.""")
+            help="""Using this enables the "No Sandbox" feature.
+                    (This setting is now always enabled by default.)""")
         parser.add_option(
             '--disable_gpu', '--disable-gpu',
             action="store_true",
             dest='disable_gpu',
             default=False,
-            help="""Using this enables the "Disable GPU" feature.""")
+            help="""Using this enables the "Disable GPU" feature.
+                    (This setting is now always enabled by default.)""")
         parser.add_option(
             '--incognito', '--incognito_mode', '--incognito-mode',
             action="store_true",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.37.13',
+    version='1.37.14',
     description='Fast, Easy, and Reliable Browser Automation & Testing.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Add option to delete all cookies between tests that reuse sessions
* Usage: (from **cmd**): ``--crumbs``
``--crumbs`` is only needed when also using ``--reuse-session``, where the same browser session is reused between tests. When not using ``--reuse-session``, every test spins up a completely clean browser session where no cookies are set.