### PR TITLE
Fix the "show_notes" feature of SeleniumBase Presenter

### DIFF
--- a/examples/presenter/ReadMe.md
+++ b/examples/presenter/ReadMe.md
@@ -21,7 +21,7 @@ pytest my_presentation.py
 ### Creating a new presentation:
 
 ```python
-self.create_presentation(name=None, theme="serif", show_notes=True)
+self.create_presentation(name=None, theme="serif")
 """ Creates a Reveal-JS presentation that you can add slides to.
     @Params
     name - If creating multiple presentations at the same time,
@@ -45,14 +45,16 @@ self.add_slide(content=None, image=None, code=None, iframe=None,
                content2=None, notes=None, name=None)
 """ Allows the user to add slides to a presentation.
     @Params
+    content - The HTML content to display on the presentation slide.
+    image - Attach an image (from a URL link) to the slide.
+    code - Attach code of any programming language to the slide.
+           Language-detection will be used to add syntax formatting.
+    iframe - Attach an iFrame (from a URL link) to the slide.
+    content2 - HTML content to display after adding an image or code.
+    notes - Additional notes to include with the slide.
+            ONLY SEEN if show_notes is set for the presentation.
     name - If creating multiple presentations at the same time,
-           use this to select the one you wish to add slides to.
-    filename - The name of the HTML file that you wish to
-               save the presentation to. (filename must end in ".html")
-    show_notes - When set to True, the Notes feature becomes enabled,
-                 which allows presenters to see notes next to slides.
-    interval - The delay time between autoplaying slides. (in seconds)
-               If set to 0 (default), autoplay is disabled.
+           use this to select the presentation to add slides to.
 """
 ```
 
@@ -60,7 +62,8 @@ self.add_slide(content=None, image=None, code=None, iframe=None,
 ### Running a presentation:
 
 ```python
-self.begin_presentation(filename="my_presentation.html", interval=0)
+self.begin_presentation(
+    filename="my_presentation.html", show_notes=True, interval=0)
 """ Begin a Reveal-JS Presentation in the web browser.
     @Params
     name - If creating multiple presentations at the same time,
@@ -159,7 +162,7 @@ class MyPresenterClass(BaseCase):
                 'from seleniumbase import BaseCase\n\n'
                 'class MyPresenterClass(BaseCase):\n\n'
                 '    def test_presenter(self):\n'
-                '        self.create_presentation()\n'
+                '        self.create_presentation(theme="serif")\n'
                 '        self.add_slide("Welcome to Presenter!")\n'
                 '        self.add_slide(\n'
                 '            "Add code to slides:",\n'
@@ -168,7 +171,8 @@ class MyPresenterClass(BaseCase):
                 '                "class MyPresenterClass(BaseCase):\\n\\n"\n'
                 '                "    def test_presenter(self):\\n"\n'
                 '                "        self.create_presentation()\\n"))\n'
-                '        self.begin_presentation(filename="demo.html")'))
+                '        self.begin_presentation(\n'
+                '            filename="demo.html", show_notes=True)'))
         self.add_slide(
             '<h3>Include <b>notes</b> with slides:</h3><br />',
             code=('self.add_slide("[Your HTML goes here]",\n'
@@ -193,7 +197,8 @@ class MyPresenterClass(BaseCase):
         self.add_slide(
             '<h2><b>The End</b></h2>',
             image="https://seleniumbase.io/img/sb_logo_10.png")
-        self.begin_presentation(filename="presenter.html", interval=0)
+        self.begin_presentation(
+            filename="presenter.html", show_notes=True, interval=0)
 ```
 
 #### This example is from [my_presentation.py](https://github.com/seleniumbase/SeleniumBase/blob/master/examples/presenter/my_presentation.py), which you can run from the ``examples/presenter`` folder with the following command:
@@ -207,10 +212,10 @@ pytest my_presentation.py
 If you want to save the presentation you created as an HTML file, use:
 
 ```python
-self.save_presentation(filename="my_presentation.html")
+self.save_presentation(filename="my_presentation.html", show_notes=True)
 ```
 
 Presentations automatically get saved when calling:
 ```python
-self.begin_presentation()
+self.begin_presentation(show_notes=True)
 ```

--- a/examples/presenter/ReadMe.md
+++ b/examples/presenter/ReadMe.md
@@ -30,8 +30,6 @@ self.create_presentation(name=None, theme="serif", show_notes=True)
             Valid themes: "serif" (default), "sky", "white", "black",
                           "simple", "league", "moon", "night",
                           "beige", "blood", and "solarized".
-    show_notes - When set to True, the Notes feature becomes enabled,
-                 which allows presenters to see notes next to slides.
 """
 ```
 
@@ -47,16 +45,14 @@ self.add_slide(content=None, image=None, code=None, iframe=None,
                content2=None, notes=None, name=None)
 """ Allows the user to add slides to a presentation.
     @Params
-    content - The HTML content to display on the presentation slide.
-    image - Attach an image (from a URL link) to the slide.
-    code - Attach code of any programming language to the slide.
-           Language-detection will be used to add syntax formatting.
-    iframe - Attach an iFrame (from a URL link) to the slide.
-    content2 - HTML content to display after adding an image or code.
-    notes - Additional notes to include with the slide.
-            ONLY SEEN if show_notes is set for the presentation.
     name - If creating multiple presentations at the same time,
-           use this to select the presentation to add slides to.
+           use this to select the one you wish to add slides to.
+    filename - The name of the HTML file that you wish to
+               save the presentation to. (filename must end in ".html")
+    show_notes - When set to True, the Notes feature becomes enabled,
+                 which allows presenters to see notes next to slides.
+    interval - The delay time between autoplaying slides. (in seconds)
+               If set to 0 (default), autoplay is disabled.
 """
 ```
 
@@ -71,6 +67,8 @@ self.begin_presentation(filename="my_presentation.html", interval=0)
            use this to select the one you wish to add slides to.
     filename - The name of the HTML file that you wish to
                save the presentation to. (filename must end in ".html")
+    show_notes - When set to True, the Notes feature becomes enabled,
+                 which allows presenters to see notes next to slides.
     interval - The delay time between autoplaying slides. (in seconds)
                If set to 0 (default), autoplay is disabled.
 """

--- a/examples/presenter/my_presentation.py
+++ b/examples/presenter/my_presentation.py
@@ -75,7 +75,7 @@ class MyPresenterClass(BaseCase):
                 'from seleniumbase import BaseCase\n\n'
                 'class MyPresenterClass(BaseCase):\n\n'
                 '    def test_presenter(self):\n'
-                '        self.create_presentation()\n'
+                '        self.create_presentation(theme="serif")\n'
                 '        self.add_slide("Welcome to Presenter!")\n'
                 '        self.add_slide(\n'
                 '            "Add code to slides:",\n'
@@ -84,7 +84,8 @@ class MyPresenterClass(BaseCase):
                 '                "class MyPresenterClass(BaseCase):\\n\\n"\n'
                 '                "    def test_presenter(self):\\n"\n'
                 '                "        self.create_presentation()\\n"))\n'
-                '        self.begin_presentation(filename="demo.html")'))
+                '        self.begin_presentation(\n'
+                '            filename="demo.html", show_notes=True)'))
         self.add_slide(
             '<h3>Include <b>notes</b> with slides:</h3><br />',
             code=('self.add_slide("[Your HTML goes here]",\n'
@@ -109,4 +110,5 @@ class MyPresenterClass(BaseCase):
         self.add_slide(
             '<h2><b>The End</b></h2>',
             image="https://seleniumbase.io/img/sb_logo_10.png")
-        self.begin_presentation(filename="presenter.html", interval=0)
+        self.begin_presentation(
+            filename="presenter.html", show_notes=True, interval=0)

--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -356,14 +356,14 @@ self.add_meta_tag(http_equiv=None, content=None)
 
 ############
 
-self.create_presentation(name=None, theme="default", show_notes=True)
+self.create_presentation(name=None, theme="default")
 
 self.add_slide(content=None, image=None, code=None, iframe=None,
                content2=None, notes=None, name=None)
 
-self.save_presentation(name=None, filename=None, interval=0)
+self.save_presentation(name=None, filename=None, show_notes=True, interval=0)
 
-self.begin_presentation(name=None, filename=None, interval=0)
+self.begin_presentation(name=None, filename=None, show_notes=True, interval=0)
 
 ############
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ coverage==5.1
 pyotp==2.3.0
 boto==2.49.0
 cffi==1.14.0
-rich==3.0.0;python_version>="3.6" and python_version<"4.0"
+rich==3.0.1;python_version>="3.6" and python_version<"4.0"
 flake8==3.7.9;python_version<"3.5"
 flake8==3.8.3;python_version>="3.5"
 pyflakes==2.1.1;python_version<"3.5"

--- a/seleniumbase/common/obfuscate.py
+++ b/seleniumbase/common/obfuscate.py
@@ -30,7 +30,7 @@ def main():
             print("\nInside a test, use the following to decrypt it:\n")
             time.sleep(0.2)
             print("    from seleniumbase import encryption")
-            print("    encryption.decrypt('%s')" % encrypted_password)
+            print('    encryption.decrypt("%s")' % encrypted_password)
             time.sleep(0.2)
     except KeyboardInterrupt:
         print("\nExiting...\n")

--- a/seleniumbase/console_scripts/sb_mkdir.py
+++ b/seleniumbase/console_scripts/sb_mkdir.py
@@ -58,8 +58,7 @@ def main():
             'Directory name must not include slashes ("/", "\\")!')
     elif os.path.exists(os.getcwd() + '/' + dir_name):
         error_msg = (
-            'Directory "%s" already exists in the current path!\n'
-            '' % dir_name)
+            'Directory "%s" already exists in the current path!' % dir_name)
     if error_msg:
         error_msg = c5 + error_msg + cr
         invalid_run_command(error_msg)

--- a/seleniumbase/console_scripts/sb_mkdir.py
+++ b/seleniumbase/console_scripts/sb_mkdir.py
@@ -66,6 +66,14 @@ def main():
     os.mkdir(dir_name)
 
     data = []
+    data.append("seleniumbase")
+    data.append("")
+    file_path = "%s/%s" % (dir_name, "requirements.txt")
+    file = codecs.open(file_path, "w+", "utf-8")
+    file.writelines("\r\n".join(data))
+    file.close()
+
+    data = []
     data.append("[pytest]")
     data.append("addopts = --capture=no --ignore conftest.py "
                 "-p no:cacheprovider")

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -3151,7 +3151,7 @@ class BaseCase(unittest.TestCase):
 
     ############
 
-    def create_presentation(self, name=None, theme="default", show_notes=True):
+    def create_presentation(self, name=None, theme="default"):
         """ Creates a Reveal-JS presentation that you can add slides to.
             @Params
             name - If creating multiple presentations at the same time,
@@ -3160,8 +3160,6 @@ class BaseCase(unittest.TestCase):
                     Valid themes: "serif" (default), "sky", "white", "black",
                                   "simple", "league", "moon", "night",
                                   "beige", "blood", and "solarized".
-            show_notes - When set to True, the Notes feature becomes enabled,
-                         which allows presenters to see notes next to slides.
         """
         if not name:
             name = "default"
@@ -3242,7 +3240,7 @@ class BaseCase(unittest.TestCase):
             name = "default"
         if name not in self._presentation_slides:
             # Create a presentation if it doesn't already exist
-            self.create_presentation(name=name, show_notes=True)
+            self.create_presentation(name=name)
         if not content:
             content = ""
         if not content2:
@@ -3273,13 +3271,16 @@ class BaseCase(unittest.TestCase):
 
         self._presentation_slides[name].append(html)
 
-    def save_presentation(self, name=None, filename=None, interval=0):
+    def save_presentation(
+            self, name=None, filename=None, show_notes=True, interval=0):
         """ Saves a Reveal-JS Presentation to a file for later use.
             @Params
             name - If creating multiple presentations at the same time,
                    use this to select the one you wish to add slides to.
             filename - The name of the HTML file that you wish to
                        save the presentation to. (filename must end in ".html")
+            show_notes - When set to True, the Notes feature becomes enabled,
+                         which allows presenters to see notes next to slides.
             interval - The delay time between autoplaying slides. (in seconds)
                        If set to 0 (default), autoplay is disabled.
         """
@@ -3300,6 +3301,10 @@ class BaseCase(unittest.TestCase):
             raise Exception('The "interval" cannot be a negative number!')
         interval_ms = float(interval) * 1000.0
 
+        show_notes_str = "false"
+        if show_notes:
+            show_notes_str = "true"
+
         the_html = ""
         for slide in self._presentation_slides[name]:
             the_html += slide
@@ -3310,13 +3315,14 @@ class BaseCase(unittest.TestCase):
             '<script src="%s"></script>\n'
             '<script src="%s"></script>\n'
             '<script>Reveal.initialize('
-            '{showNotes: true, slideNumber: true, '
+            '{showNotes: %s, slideNumber: true, '
             'autoSlide: %s,});'
             '</script>\n'
             '</body>\n'
             '</html>\n'
             '' % (constants.Reveal.MIN_JS,
                   constants.PrettifyJS.RUN_PRETTIFY_JS,
+                  show_notes_str,
                   interval_ms))
 
         saved_presentations_folder = constants.Presentations.SAVED_FOLDER
@@ -3334,13 +3340,16 @@ class BaseCase(unittest.TestCase):
         print('\n>>> [%s] was saved!\n' % file_path)
         return file_path
 
-    def begin_presentation(self, name=None, filename=None, interval=0):
+    def begin_presentation(
+            self, name=None, filename=None, show_notes=True, interval=0):
         """ Begin a Reveal-JS Presentation in the web browser.
             @Params
             name - If creating multiple presentations at the same time,
                    use this to select the one you wish to add slides to.
             filename - The name of the HTML file that you wish to
                        save the presentation to. (filename must end in ".html")
+            show_notes - When set to True, the Notes feature becomes enabled,
+                         which allows presenters to see notes next to slides.
             interval - The delay time between autoplaying slides. (in seconds)
                        If set to 0 (default), autoplay is disabled.
         """
@@ -3366,7 +3375,8 @@ class BaseCase(unittest.TestCase):
             '<p class="End_Presentation_Now"> </p>\n</section>\n')
         self._presentation_slides[name].append(end_slide)
         file_path = self.save_presentation(
-            name=name, filename=filename, interval=interval)
+            name=name, filename=filename,
+            show_notes=show_notes, interval=interval)
         self._presentation_slides[name].pop()
 
         self.open_html_file(file_path)

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
         'pyotp==2.3.0',
         'boto==2.49.0',
         'cffi==1.14.0',
-        'rich==3.0.0;python_version>="3.6" and python_version<"4.0"',
+        'rich==3.0.1;python_version>="3.6" and python_version<"4.0"',
         'flake8==3.7.9;python_version<"3.5"',
         'flake8==3.8.3;python_version>="3.5"',
         'pyflakes==2.1.1;python_version<"3.5"',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.42.1',
+    version='1.42.2',
     description='Fast, Easy, and Reliable Browser Automation & Testing.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Fix the "show_notes" feature of SeleniumBase Presenter

* Fix Presenter "show_notes" and move arg to different area
* Include requirements.txt with "sbase mkdir DIR"
* Update a Python dependency (rich==3.0.1)

#### Updated Methods:
```python
self.create_presentation(name=None, theme="default")

self.add_slide(content=None, image=None, code=None, iframe=None,
               content2=None, notes=None, name=None)

self.save_presentation(name=None, filename=None, show_notes=True, interval=0)

self.begin_presentation(name=None, filename=None, show_notes=True, interval=0)
```