### PR TITLE
Keep the current URL when using "--reuse-session"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ coverage==5.2
 pyotp==2.3.0
 boto==2.49.0
 cffi==1.14.0
-rich==3.3.1;python_version>="3.6" and python_version<"4.0"
+rich==3.3.2;python_version>="3.6" and python_version<"4.0"
 flake8==3.7.9;python_version<"3.5"
 flake8==3.8.3;python_version>="3.5"
 pyflakes==2.1.1;python_version<"3.5"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -5428,9 +5428,11 @@ class BaseCase(unittest.TestCase):
                     new_start_page = "http://" + self.start_page
                     if page_utils.is_valid_url(new_start_page):
                         self.open(new_start_page)
-            else:
+            elif self._crumbs:
                 if self.get_current_url() != "data:,":
                     self.open("data:,")
+            else:
+                pass
         else:
             # Launch WebDriver for both Pytest and Nosetests
             self.driver = self.get_new_driver(browser=self.browser,

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.42.12',
+    version='1.42.13',
     description='Fast, Easy, and Reliable Browser Automation & Testing.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
         'pyotp==2.3.0',
         'boto==2.49.0',
         'cffi==1.14.0',
-        'rich==3.3.1;python_version>="3.6" and python_version<"4.0"',
+        'rich==3.3.2;python_version>="3.6" and python_version<"4.0"',
         'flake8==3.7.9;python_version<"3.5"',
         'flake8==3.8.3;python_version>="3.5"',
         'pyflakes==2.1.1;python_version<"3.5"',


### PR DESCRIPTION
### Keep the current URL when using ``--reuse-session``

When using ``--reuse-session`` (alt: ``--rs``), which allows you to reuse the same browser window between tests, the browser will now continue from the URL it left off at, rather than going to a blank page first.
The exception to this rule is when also using ``--crumbs``, which will clear out cookies and then navigate to a blank page before resuming the tests in the same browser window.