### PR TITLE
Improve basic logging with date, time, and time-zone info

### DIFF
--- a/seleniumbase/core/log_helper.py
+++ b/seleniumbase/core/log_helper.py
@@ -1,4 +1,5 @@
 import codecs
+import datetime
 import os
 import shutil
 import sys
@@ -33,10 +34,34 @@ def log_test_failure_data(test, test_logpath, driver, browser, url=None):
         last_page = url
     else:
         last_page = get_last_page(driver)
+    timestamp = str(int(time.time())) + "  (Unix Timestamp)"
+    now = datetime.datetime.now()
+    utc_offset = -time.timezone / 3600.0
+    utc_str = "UTC+0"
+    if utc_offset > 0:
+        utc_str = "UTC+%s" % utc_offset
+    elif utc_offset < 0:
+        utc_str = "UTC%s" % utc_offset
+    utc_str = utc_str.replace('.5', '.3').replace('.', ':') + "0"
+    time_zone = '(' + '/'.join(time.tzname) + ', ' + utc_str + ')'
+    # Use [Day-of-Week, Month Day, Year] format when time zone < GMT/UTC-3
+    the_date = now.strftime("%A, %B %d, %Y").replace(' 0', ' ')
+    if utc_offset >= -3:
+        # Use [Day-of-Week, Day Month Year] format when time zone >= GMT/UTC-3
+        the_date = now.strftime("%A, %d %B %Y").replace(' 0', ' ')
+    the_time = now.strftime("%I:%M:%S %p  ") + time_zone
+    if the_time.startswith("0"):
+        the_time = the_time[1:]
+    test_id = get_test_id(test)
     data_to_save = []
+    data_to_save.append("%s" % test_id)
+    data_to_save.append("----------------------------------------------------")
     data_to_save.append("Last Page: %s" % last_page)
     data_to_save.append("  Browser: %s" % browser)
-    data_to_save.append("Timestamp: %s" % int(time.time()))
+    data_to_save.append("Timestamp: %s" % timestamp)
+    data_to_save.append("     Date: %s" % the_date)
+    data_to_save.append("     Time: %s" % the_time)
+    data_to_save.append("----------------------------------------------------")
     if sys.version_info[0] >= 3 and hasattr(test, '_outcome') and (
             hasattr(test._outcome, 'errors') and test._outcome.errors):
         try:
@@ -91,6 +116,16 @@ def log_page_source(test_logpath, driver, source=None):
     rendered_source = get_html_source_with_base_href(driver, page_source)
     html_file.write(rendered_source)
     html_file.close()
+
+
+def get_test_id(test):
+    test_id = "%s.%s.%s" % (
+        test.__class__.__module__,
+        test.__class__.__name__,
+        test._testMethodName)
+    if test._sb_test_identifier and len(str(test._sb_test_identifier)) > 6:
+        test_id = test._sb_test_identifier
+    return test_id
 
 
 def get_last_page(driver):

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.46.10',
+    version='1.46.11',
     description='Web Automation and Test Framework - https://seleniumbase.io',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Improve basic logging with date, time, and time-zone info

Example ``basic_test_info.txt`` file from ``latest_logs/``:

```bash
examples.test_fail.MyTestClass.test_find_army_of_robots_on_xkcd_desert_island
----------------------------------------------------
Last Page: https://xkcd.com/731/
  Browser: chrome
Timestamp: 1597818345  (Unix Timestamp)
     Date: Wednesday, August 19, 2020
     Time: 2:25:45 AM  (EST/EDT, UTC-5:00)
----------------------------------------------------
Traceback: File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/case.py", line 615, in run
    testMethod()
  File "/Users/michael/github/SeleniumBase/examples/test_fail.py", line 17, in test_find_army_of_robots_on_xkcd_desert_island
    self.assert_element("div#ARMY_OF_ROBOTS", timeout=1)
  File "/Users/michael/github/SeleniumBase/seleniumbase/fixtures/base_case.py", line 4852, in assert_element
    self.wait_for_element_visible(selector, by=by, timeout=timeout)
  File "/Users/michael/github/SeleniumBase/seleniumbase/fixtures/base_case.py", line 3211, in wait_for_element_visible
    self.driver, selector, by, timeout)
  File "/Users/michael/github/SeleniumBase/seleniumbase/fixtures/page_actions.py", line 299, in wait_for_element_visible
    timeout_exception(NoSuchElementException, message)
  File "/Users/michael/github/SeleniumBase/seleniumbase/fixtures/page_actions.py", line 117, in timeout_exception
    raise exc(message)
Exception: Message: 
 Element {div#ARMY_OF_ROBOTS} was not present after 1 second!
```