### PR TITLE
Fix edge case with iframe switching

### DIFF
--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -1687,7 +1687,7 @@ class BaseCase(unittest.TestCase):
             timeout = settings.SMALL_TIMEOUT
         if self.timeout_multiplier and timeout == settings.SMALL_TIMEOUT:
             timeout = self.__get_new_timeout(timeout)
-        if self.is_element_visible(frame):
+        if type(frame) is str and self.is_element_visible(frame):
             try:
                 self.scroll_to(frame, timeout=1)
             except Exception:

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.48.4',
+    version='1.48.5',
     description='Web Automation and Test Framework - https://seleniumbase.io',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Fix edge case with iframe switching
* Only scroll to iframes before switching to them if the identifier is a string

An iframe identifier can be a string, an int, or a web element, but the scroll_to() method expects a string selector for finding the element first.