### PR TITLE
Another update to the xpath-to-css converter

### DIFF
--- a/seleniumbase/fixtures/xpath_to_css.py
+++ b/seleniumbase/fixtures/xpath_to_css.py
@@ -172,6 +172,8 @@ def convert_xpath_to_css(xpath):
     if xpath[0] != '"' and xpath[-1] != '"' and xpath.count('"') % 2 == 0:
         xpath = _handle_brackets_in_strings(xpath)
     xpath = xpath.replace("descendant-or-self::*/", "descORself/")
+    if len(xpath) > 3:
+        xpath = xpath[0:3] + xpath[3:].replace('//', '/descORself/')
 
     if " and contains(@" in xpath and xpath.count(" and contains(@") == 1:
         spot1 = xpath.find(" and contains(@")
@@ -211,7 +213,9 @@ def convert_xpath_to_css(xpath):
     css = css.replace(" descORself > ", ' ')
     css = css.replace("/descORself/*", ' ')
     css = css.replace("/descORself/", ' ')
+    css = css.replace("descORself > ", '')
     css = css.replace("descORself/", ' ')
+    css = css.replace("descORself", ' ')
     css = css.replace("_STAR_=", "*=")
     css = css.replace("]/", "] ")
     css = css.replace("] *[", "] > [")

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.49.6',
+    version='1.49.7',
     description='Web Automation and Test Framework - https://seleniumbase.io',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Another update to the xpath-to-css converter

* Handle the case of ``//`` in the middle of an xpath selector

Example:

```python
self.convert_xpath_to_css("//section//p/p//div")
'section p > p div'
```

See the xpath cheatsheet for more details: https://devhints.io/xpath