### PR TITLE
Add expected methods

### DIFF
--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -321,6 +321,7 @@ self.set_value(selector, text, by=By.CSS_SELECTOR, timeout=None)
 
 self.js_update_text(selector, text, by=By.CSS_SELECTOR, timeout=None)
 # Duplicates: self.js_type(selector, text, by=By.CSS_SELECTOR, timeout=None)
+#             self.set_text(selector, text, by=By.CSS_SELECTOR, timeout=None)
 
 self.jquery_update_text(selector, text, by=By.CSS_SELECTOR, timeout=None)
 

--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -33,6 +33,8 @@ self.add_text(selector, text, by=By.CSS_SELECTOR, timeout=None)
 
 self.submit(selector, by=By.CSS_SELECTOR)
 
+self.clear(selector, by=By.CSS_SELECTOR, timeout=None)
+
 self.refresh_page()
 # Duplicates: self.refresh(), self.reload(), self.reload_page()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ ipython==6.5.0;python_version>="3.5" and python_version<"3.6"
 ipython==7.16.1;python_version>="3.6" and python_version<"3.7"
 ipython==7.18.1;python_version>="3.7"
 colorama==0.4.3
-pymysql==0.10.0
+pymysql==0.10.1
 coverage==5.2.1
 brython==3.8.10
 pyotp==2.4.0

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -3155,6 +3155,29 @@ class BaseCase(unittest.TestCase):
             except Exception:
                 pass
 
+    def set_text(self, selector, text, by=By.CSS_SELECTOR, timeout=None):
+        """ Same as self.js_update_text()
+            JavaScript + send_keys are used to update a text field.
+            Performs self.set_value() and triggers event listeners.
+            If text ends in "\n", set_value() presses RETURN after.
+            Works faster than send_keys() alone due to the JS call. """
+        if not timeout:
+            timeout = settings.LARGE_TIMEOUT
+        if self.timeout_multiplier and timeout == settings.LARGE_TIMEOUT:
+            timeout = self.__get_new_timeout(timeout)
+        selector, by = self.__recalculate_selector(selector, by)
+        if type(text) is int or type(text) is float:
+            text = str(text)
+        self.set_value(
+            selector, text, by=by, timeout=timeout)
+        if not text.endswith('\n'):
+            try:
+                element = page_actions.wait_for_element_present(
+                    self.driver, selector, by, timeout=0.2)
+                element.send_keys(" \b")
+            except Exception:
+                pass
+
     def jquery_update_text(self, selector, text, by=By.CSS_SELECTOR,
                            timeout=None):
         """ This method uses jQuery to update a text field.

--- a/seleniumbase/translate/chinese.py
+++ b/seleniumbase/translate/chinese.py
@@ -177,6 +177,10 @@ class 硒测试用例(BaseCase):  # noqa
         # submit(selector)
         return self.submit(*args, **kwargs)
 
+    def 清除(self, *args, **kwargs):
+        # clear(selector)
+        return self.clear(*args, **kwargs)
+
     def JS单击(self, *args, **kwargs):
         # js_click(selector)
         return self.js_click(*args, **kwargs)
@@ -459,6 +463,10 @@ class 硒测试用例(BaseCase):  # noqa
     def 查找文本(self, *args, **kwargs):
         # find_text(text, selector="html")  # Same as wait_for_text
         return self.find_text(*args, **kwargs)
+
+    def 设置文本(self, *args, **kwargs):
+        # set_text(selector, text)
+        return self.set_text(*args, **kwargs)
 
     def 获取属性(self, *args, **kwargs):
         # get_attribute(selector, attribute)

--- a/seleniumbase/translate/dutch.py
+++ b/seleniumbase/translate/dutch.py
@@ -177,6 +177,10 @@ class Testgeval(BaseCase):
         # submit(selector)
         return self.submit(*args, **kwargs)
 
+    def wissen(self, *args, **kwargs):
+        # clear(selector)
+        return self.clear(*args, **kwargs)
+
     def js_klik(self, *args, **kwargs):
         # js_click(selector)
         return self.js_click(*args, **kwargs)
@@ -460,6 +464,10 @@ class Testgeval(BaseCase):
         # find_text(text, selector="html")  # Same as wait_for_text
         return self.find_text(*args, **kwargs)
 
+    def tekst_instellen(self, *args, **kwargs):
+        # set_text(selector, text)
+        return self.set_text(*args, **kwargs)
+
     def kenmerk_ophalen(self, *args, **kwargs):
         # get_attribute(selector, attribute)
         return self.get_attribute(*args, **kwargs)
@@ -476,7 +484,7 @@ class Testgeval(BaseCase):
         # write(selector, text)  # Same as update_text()
         return self.write(*args, **kwargs)
 
-    def kenmerk_thema_van_bericht(self, *args, **kwargs):
+    def thema_van_bericht_instellen(self, *args, **kwargs):
         # set_messenger_theme(theme="default", location="default")
         return self.set_messenger_theme(*args, **kwargs)
 

--- a/seleniumbase/translate/french.py
+++ b/seleniumbase/translate/french.py
@@ -177,6 +177,10 @@ class CasDeBase(BaseCase):
         # submit(selector)
         return self.submit(*args, **kwargs)
 
+    def effacer(self, *args, **kwargs):
+        # clear(selector)
+        return self.clear(*args, **kwargs)
+
     def js_cliquer(self, *args, **kwargs):
         # js_click(selector)
         return self.js_click(*args, **kwargs)
@@ -459,6 +463,10 @@ class CasDeBase(BaseCase):
     def trouver_texte(self, *args, **kwargs):
         # find_text(text, selector="html")  # Same as wait_for_text
         return self.find_text(*args, **kwargs)
+
+    def définir_texte(self, *args, **kwargs):
+        # set_text(selector, text)
+        return self.set_text(*args, **kwargs)
 
     def obtenir_attribut(self, *args, **kwargs):
         # get_attribute(selector, attribute)

--- a/seleniumbase/translate/italian.py
+++ b/seleniumbase/translate/italian.py
@@ -177,6 +177,10 @@ class CasoDiProva(BaseCase):
         # submit(selector)
         return self.submit(*args, **kwargs)
 
+    def cancellare(self, *args, **kwargs):
+        # clear(selector)
+        return self.clear(*args, **kwargs)
+
     def js_fare_clic(self, *args, **kwargs):
         # js_click(selector)
         return self.js_click(*args, **kwargs)
@@ -459,6 +463,10 @@ class CasoDiProva(BaseCase):
     def trovare_testo(self, *args, **kwargs):
         # find_text(text, selector="html")  # Same as wait_for_text
         return self.find_text(*args, **kwargs)
+
+    def impostare_testo(self, *args, **kwargs):
+        # set_text(selector, text)
+        return self.set_text(*args, **kwargs)
 
     def ottenere_attributo(self, *args, **kwargs):
         # get_attribute(selector, attribute)

--- a/seleniumbase/translate/japanese.py
+++ b/seleniumbase/translate/japanese.py
@@ -177,6 +177,10 @@ class セレニウムテストケース(BaseCase):  # noqa
         # submit(selector)
         return self.submit(*args, **kwargs)
 
+    def クリアする(self, *args, **kwargs):
+        # clear(selector)
+        return self.clear(*args, **kwargs)
+
     def JSクリックして(self, *args, **kwargs):
         # js_click(selector)
         return self.js_click(*args, **kwargs)
@@ -459,6 +463,10 @@ class セレニウムテストケース(BaseCase):  # noqa
     def テキストを見つける(self, *args, **kwargs):
         # find_text(text, selector="html")  # Same as wait_for_text
         return self.find_text(*args, **kwargs)
+
+    def テキストを設定する(self, *args, **kwargs):
+        # set_text(selector, text)
+        return self.set_text(*args, **kwargs)
 
     def 属性を取得する(self, *args, **kwargs):
         # get_attribute(selector, attribute)

--- a/seleniumbase/translate/korean.py
+++ b/seleniumbase/translate/korean.py
@@ -177,6 +177,10 @@ class 셀레늄_테스트_케이스(BaseCase):  # noqa
         # submit(selector)
         return self.submit(*args, **kwargs)
 
+    def 지우려면(self, *args, **kwargs):
+        # clear(selector)
+        return self.clear(*args, **kwargs)
+
     def JS_클릭(self, *args, **kwargs):
         # js_click(selector)
         return self.js_click(*args, **kwargs)
@@ -459,6 +463,10 @@ class 셀레늄_테스트_케이스(BaseCase):  # noqa
     def 텍스트_찾기(self, *args, **kwargs):
         # find_text(text, selector="html")  # Same as wait_for_text
         return self.find_text(*args, **kwargs)
+
+    def 텍스트_설정(self, *args, **kwargs):
+        # set_text(selector, text)
+        return self.set_text(*args, **kwargs)
 
     def 특성_검색(self, *args, **kwargs):
         # get_attribute(selector, attribute)

--- a/seleniumbase/translate/master_dict.py
+++ b/seleniumbase/translate/master_dict.py
@@ -731,6 +731,18 @@ class MD:
     md["submit"][8] = "отправить"
     md["submit"][9] = "enviar"
 
+    md["clear"] = ["*"] * num_langs
+    md["clear"][0] = "clear"
+    md["clear"][1] = "清除"
+    md["clear"][2] = "wissen"
+    md["clear"][3] = "effacer"
+    md["clear"][4] = "cancellare"
+    md["clear"][5] = "クリアする"
+    md["clear"][6] = "지우려면"
+    md["clear"][7] = "limpar"
+    md["clear"][8] = "очистить"
+    md["clear"][9] = "despejar"
+
     md["js_click"] = ["*"] * num_langs
     md["js_click"][0] = "js_click"
     md["js_click"][1] = "JS单击"
@@ -1548,6 +1560,18 @@ class MD:
     md["find_text"][8] = "найти_текст"
     md["find_text"][9] = "encontrar_texto"
 
+    md["set_text"] = ["*"] * num_langs
+    md["set_text"][0] = "set_text"
+    md["set_text"][1] = "设置文本"
+    md["set_text"][2] = "tekst_instellen"
+    md["set_text"][3] = "définir_texte"
+    md["set_text"][4] = "impostare_testo"
+    md["set_text"][5] = "テキストを設定する"
+    md["set_text"][6] = "텍스트_설정"
+    md["set_text"][7] = "definir_texto"
+    md["set_text"][8] = "набор_текст"
+    md["set_text"][9] = "establecer_texto"
+
     md["get_attribute"] = ["*"] * num_langs
     md["get_attribute"][0] = "get_attribute"
     md["get_attribute"][1] = "获取属性"
@@ -1611,7 +1635,7 @@ class MD:
     md["set_messenger_theme"] = ["*"] * num_langs
     md["set_messenger_theme"][0] = "set_messenger_theme"
     md["set_messenger_theme"][1] = "设置消息主题"
-    md["set_messenger_theme"][2] = "kenmerk_thema_van_bericht"
+    md["set_messenger_theme"][2] = "thema_van_bericht_instellen"
     md["set_messenger_theme"][3] = "définir_thème_du_message"
     md["set_messenger_theme"][4] = "impostare_tema_del_messaggio"
     md["set_messenger_theme"][5] = "メッセージのスタイルを設定する"

--- a/seleniumbase/translate/portuguese.py
+++ b/seleniumbase/translate/portuguese.py
@@ -177,6 +177,10 @@ class CasoDeTeste(BaseCase):
         # submit(selector)
         return self.submit(*args, **kwargs)
 
+    def limpar(self, *args, **kwargs):
+        # clear(selector)
+        return self.clear(*args, **kwargs)
+
     def js_clique(self, *args, **kwargs):
         # js_click(selector)
         return self.js_click(*args, **kwargs)
@@ -459,6 +463,10 @@ class CasoDeTeste(BaseCase):
     def encontrar_texto(self, *args, **kwargs):
         # find_text(text, selector="html")  # Same as wait_for_text
         return self.find_text(*args, **kwargs)
+
+    def definir_texto(self, *args, **kwargs):
+        # set_text(selector, text)
+        return self.set_text(*args, **kwargs)
 
     def obter_atributo(self, *args, **kwargs):
         # get_attribute(selector, attribute)

--- a/seleniumbase/translate/russian.py
+++ b/seleniumbase/translate/russian.py
@@ -177,6 +177,10 @@ class ТестНаСелен(BaseCase):  # noqa
         # submit(selector)
         return self.submit(*args, **kwargs)
 
+    def очистить(self, *args, **kwargs):
+        # clear(selector)
+        return self.clear(*args, **kwargs)
+
     def JS_нажмите(self, *args, **kwargs):
         # js_click(selector)
         return self.js_click(*args, **kwargs)
@@ -459,6 +463,10 @@ class ТестНаСелен(BaseCase):  # noqa
     def найти_текст(self, *args, **kwargs):
         # find_text(text, selector="html")  # Same as wait_for_text
         return self.find_text(*args, **kwargs)
+
+    def набор_текст(self, *args, **kwargs):
+        # set_text(selector, text)
+        return self.set_text(*args, **kwargs)
 
     def получить_атрибут(self, *args, **kwargs):
         # get_attribute(selector, attribute)

--- a/seleniumbase/translate/spanish.py
+++ b/seleniumbase/translate/spanish.py
@@ -177,6 +177,10 @@ class CasoDePrueba(BaseCase):
         # submit(selector)
         return self.submit(*args, **kwargs)
 
+    def despejar(self, *args, **kwargs):
+        # clear(selector)
+        return self.clear(*args, **kwargs)
+
     def js_haga_clic(self, *args, **kwargs):
         # js_click(selector)
         return self.js_click(*args, **kwargs)
@@ -459,6 +463,10 @@ class CasoDePrueba(BaseCase):
     def encontrar_texto(self, *args, **kwargs):
         # find_text(text, selector="html")  # Same as wait_for_text
         return self.find_text(*args, **kwargs)
+
+    def establecer_texto(self, *args, **kwargs):
+        # set_text(selector, text)
+        return self.set_text(*args, **kwargs)
 
     def obtener_atributo(self, *args, **kwargs):
         # get_attribute(selector, attribute)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.49.9',
+    version='1.49.10',
     description='Web Automation and Test Framework - https://seleniumbase.io',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup(
         'ipython==7.16.1;python_version>="3.6" and python_version<"3.7"',
         'ipython==7.18.1;python_version>="3.7"',
         'colorama==0.4.3',
-        'pymysql==0.10.0',
+        'pymysql==0.10.1',
         'coverage==5.2.1',
         'brython==3.8.10',
         'pyotp==2.4.0',


### PR DESCRIPTION
### Add expected methods
* Add ``self.clear(SELECTOR)``
* Add ``self.set_text(SELECTOR, TEXT)``
* Update SeleniumBase translations
* Also set the ``pymysql`` requirement to version ``0.10.1``

#### Reasoning for the duplicate methods:
* Although most methods that type text already clear out the text field first, and although clearing out the text field can already be done with ``self.type(SELECTOR, "")``, I'm adding the ``self.clear(SELECTOR)`` method to avoid confusion because developers will expect that method to exist.
* Developers would also expect there to be a ``self.set_text(SELECTOR, TEXT)`` method (<i>even though methods already exist that do the same thing</i>) because there's a ``self.get_text(SELECTOR)`` method and a ``self.set_attribute(SELECTOR, ATTRIBUTE, VALUE)`` method, which sound similar.