### PR TITLE
Update the console scripts' tools for generating page objects

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
     displayName: 'Check the console scripts interface'
 
   - script: |
-      seleniumbase install chromedriver
+      seleniumbase install chromedriver latest
     displayName: 'Install chromedriver'
 
   - script: |

--- a/examples/decryption_test.py
+++ b/examples/decryption_test.py
@@ -11,13 +11,13 @@ class MyTestClass(BaseCase):
 
     def test_rate_limited_printing(self):
         self.open("https://www.saucedemo.com/")
-        self.update_text("#user-name", "standard_user")
+        self.type("#user-name", "standard_user")
 
         encrypted_password = "$^*ENCRYPT=S3BDTAdCWzMmKEY8Gjg=?&#$"
         print("\nEncrypted Password = %s" % encrypted_password)
         password = encryption.decrypt(encrypted_password)
         print("Decrypted Password = %s" % password)
-        self.update_text("#password", password)
+        self.type("#password", password)
 
         self.click('input[type="submit"]')
         self.assert_text("Products", "div.product_label")

--- a/examples/test_usefixtures.py
+++ b/examples/test_usefixtures.py
@@ -6,7 +6,7 @@ class Test_UseFixtures():
     def test_usefixtures_on_class(self):
         sb = self.sb
         sb.open("https://google.com/ncr")
-        sb.update_text('input[title="Search"]', 'SeleniumBase\n')
+        sb.type('input[title="Search"]', 'SeleniumBase\n')
         sb.click('a[href*="github.com/seleniumbase/SeleniumBase"]')
         sb.assert_text("SeleniumBase", 'strong[itemprop="name"]')
         sb.assert_text("integrations")

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ brython==3.8.10
 pyotp==2.4.0
 boto==2.49.0
 cffi==1.14.2
-rich==6.2.0;python_version>="3.6" and python_version<"4.0"
+rich==7.0.0;python_version>="3.6" and python_version<"4.0"
 flake8==3.7.9;python_version<"3.5"
 flake8==3.8.3;python_version>="3.5"
 pyflakes==2.1.1;python_version<"3.5"

--- a/seleniumbase/console_scripts/ReadMe.md
+++ b/seleniumbase/console_scripts/ReadMe.md
@@ -73,7 +73,7 @@ Creates a new SeleniumBase test file with boilerplate code.
 If the file already exists, an error is raised.
 By default, uses English mode and creates a
 boilerplate with the 5 most common SeleniumBase
-methods, which are "open", "click", "update_text",
+methods, which are "open", "type", "click",
 "assert_element", and "assert_text". If using the
 basic boilerplate option, only the "open" method
 is included.

--- a/seleniumbase/console_scripts/objectify.py
+++ b/seleniumbase/console_scripts/objectify.py
@@ -235,7 +235,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.click'''
-                r'''\(([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -275,7 +275,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.js_click'''
-                r'''\(([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -315,7 +315,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.slow_click'''
-                r'''\(([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -346,6 +346,86 @@ def process_test_file(
             seleniumbase_lines.append(command)
             continue
 
+        # Handle self.click_visible_elements(SELECTOR)
+        if not object_dict:
+            data = re.match(
+                r'''^(\s*)self\.click_visible_elements'''
+                r'''\((r?['"][\S\s]+['"])\)([\S\s]*)'''
+                r'''$''', line)
+        else:
+            data = re.match(
+                r'''^(\s*)self\.click_visible_elements'''
+                r'''\(([\S]+)\)([\S\s]*)'''
+                r'''$''', line)
+        if data:
+            whitespace = data.group(1)
+            selector = '%s' % data.group(2)
+            selector = remove_extra_slashes(selector)
+            page_selectors.append(selector)
+            comments = data.group(3)
+            command = '''%sself.click_visible_elements(%s)%s''' % (
+                whitespace, selector, comments)
+            if selector_dict:
+                if add_comments:
+                    comments = "  # %s" % selector
+                selector = optimize_selector(selector)
+                if selector in selector_dict.keys():
+                    selector_object = selector_dict[selector]
+                    changed.append(selector_object.split('.')[0])
+                    command = '''%sself.click_visible_elements(%s)%s''' % (
+                        whitespace, selector_object, comments)
+            if object_dict:
+                if not add_comments:
+                    comments = ""
+                object_name = selector
+                if object_name in object_dict.keys():
+                    selector_object = object_dict[object_name]
+                    changed.append(object_name.split('.')[0])
+                    command = '''%sself.click_visible_elements(%s)%s''' % (
+                        whitespace, selector_object, comments)
+            seleniumbase_lines.append(command)
+            continue
+
+        # Handle self.switch_to_frame(SELECTOR)
+        if not object_dict:
+            data = re.match(
+                r'''^(\s*)self\.switch_to_frame'''
+                r'''\((r?['"][\S\s]+['"])\)([\S\s]*)'''
+                r'''$''', line)
+        else:
+            data = re.match(
+                r'''^(\s*)self\.switch_to_frame'''
+                r'''\(([\S]+)\)([\S\s]*)'''
+                r'''$''', line)
+        if data:
+            whitespace = data.group(1)
+            selector = '%s' % data.group(2)
+            selector = remove_extra_slashes(selector)
+            page_selectors.append(selector)
+            comments = data.group(3)
+            command = '''%sself.switch_to_frame(%s)%s''' % (
+                whitespace, selector, comments)
+            if selector_dict:
+                if add_comments:
+                    comments = "  # %s" % selector
+                selector = optimize_selector(selector)
+                if selector in selector_dict.keys():
+                    selector_object = selector_dict[selector]
+                    changed.append(selector_object.split('.')[0])
+                    command = '''%sself.switch_to_frame(%s)%s''' % (
+                        whitespace, selector_object, comments)
+            if object_dict:
+                if not add_comments:
+                    comments = ""
+                object_name = selector
+                if object_name in object_dict.keys():
+                    selector_object = object_dict[object_name]
+                    changed.append(object_name.split('.')[0])
+                    command = '''%sself.switch_to_frame(%s)%s''' % (
+                        whitespace, selector_object, comments)
+            seleniumbase_lines.append(command)
+            continue
+
         # Handle self.assert_element(SELECTOR)
         if not object_dict:
             data = re.match(
@@ -355,7 +435,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.assert_element'''
-                r'''\(([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -395,7 +475,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.assert_element_(\S*)'''
-                r'''\(([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -436,7 +516,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.find_element'''
-                r'''\(([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -476,7 +556,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.get_element'''
-                r'''\(([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -516,7 +596,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.wait_for_element'''
-                r'''\(([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -556,7 +636,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.wait_for_element_(\S*)'''
-                r'''\(([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -597,7 +677,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.update_text'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+),\s?([\S\s]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -638,7 +718,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.type'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+),\s?([\S\s]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -679,7 +759,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.input'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+),\s?([\S\s]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -720,7 +800,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.write'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+),\s?([\S\s]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -761,7 +841,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.add_text'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+),\s?([\S\s]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -802,7 +882,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.send_keys'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+),\s?([\S\s]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -843,7 +923,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.set_value'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+),\s?([\S\s]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -875,6 +955,142 @@ def process_test_file(
             seleniumbase_lines.append(command)
             continue
 
+        # Handle self.hover_and_click(SELECTOR, SELECTOR)
+        if not object_dict:
+            data = re.match(
+                r'''^(\s*)self\.hover_and_click'''
+                r'''\((r?['"][\S\s]+['"]),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''$''', line)
+        else:
+            data = re.match(
+                r'''^(\s*)self\.hover_and_click'''
+                r'''\(([\S]+),\s?([\S]+)\)([\S\s]*)'''
+                r'''$''', line)
+        if data:
+            whitespace = data.group(1)
+            selector1 = '%s' % data.group(2)
+            selector1 = remove_extra_slashes(selector1)
+            page_selectors.append(selector1)
+            selector2 = '%s' % data.group(3)
+            selector2 = remove_extra_slashes(selector2)
+            page_selectors.append(selector2)
+            comments = data.group(4)
+            command = '''%sself.hover_and_click(%s, %s)%s''' % (
+                whitespace, selector1, selector2, comments)
+            if selector_dict:
+                if add_comments:
+                    comments = "  # %s" % selector
+                selector1 = optimize_selector(selector1)
+                selector2 = optimize_selector(selector2)
+                if selector1 in selector_dict.keys() and (
+                        selector2 in selector_dict.keys()):
+                    selector_object1 = selector_dict[selector1]
+                    selector_object2 = selector_dict[selector2]
+                    changed.append(selector_object1.split('.')[0])
+                    changed.append(selector_object2.split('.')[0])
+                    command = '''%sself.hover_and_click(%s, %s)%s''' % (
+                        whitespace, selector_object1, selector_object2,
+                        comments)
+            if object_dict:
+                if not add_comments:
+                    comments = ""
+                object_name1 = selector1
+                object_name2 = selector2
+                if object_name1 in object_dict.keys() and (
+                        object_name2 in object_dict.keys()):
+                    selector_object1 = object_dict[object_name1]
+                    selector_object2 = object_dict[object_name2]
+                    changed.append(object_name1.split('.')[0])
+                    changed.append(object_name2.split('.')[0])
+                    command = '''%sself.hover_and_click(%s, %s)%s''' % (
+                        whitespace, selector_object1, selector_object2,
+                        comments)
+            seleniumbase_lines.append(command)
+            continue
+
+        # Handle self.press_*_arrow(SELECTOR)
+        if not object_dict:
+            data = re.match(
+                r'''^(\s*)self\.press_(\S*)_arrow'''
+                r'''\((r?['"][\S\s]+['"])\)([\S\s]*)'''
+                r'''$''', line)
+        else:
+            data = re.match(
+                r'''^(\s*)self\.press_(\S*)_arrow'''
+                r'''\(([\S]+)\)([\S\s]*)'''
+                r'''$''', line)
+        if data:
+            whitespace = data.group(1)
+            arrow = '%s' % data.group(2)
+            selector = '%s' % data.group(3)
+            selector = remove_extra_slashes(selector)
+            page_selectors.append(selector)
+            comments = data.group(4)
+            command = '''%sself.press_%s_arrow(%s)%s''' % (
+                whitespace, arrow, selector, comments)
+            if selector_dict:
+                if add_comments:
+                    comments = "  # %s" % selector
+                selector = optimize_selector(selector)
+                if selector in selector_dict.keys():
+                    selector_object = selector_dict[selector]
+                    changed.append(selector_object.split('.')[0])
+                    command = '''%sself.press_%s_arrow(%s)%s''' % (
+                        whitespace, arrow, selector_object, comments)
+            if object_dict:
+                if not add_comments:
+                    comments = ""
+                object_name = selector
+                if object_name in object_dict.keys():
+                    selector_object = object_dict[object_name]
+                    changed.append(object_name.split('.')[0])
+                    command = '''%sself.press_%s_arrow(%s)%s''' % (
+                        whitespace, arrow, selector_object, comments)
+            seleniumbase_lines.append(command)
+            continue
+
+        # Handle self.press_*_arrow(SELECTOR, TIMES)
+        if not object_dict:
+            data = re.match(
+                r'''^(\s*)self\.press_(\S*)_arrow'''
+                r'''\((r?['"][\S\s]+['"]),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''$''', line)
+        else:
+            data = re.match(
+                r'''^(\s*)self\.press_(\S*)_arrow'''
+                r'''\(([\S]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''$''', line)
+        if data:
+            whitespace = data.group(1)
+            arrow = '%s' % data.group(2)
+            selector = '%s' % data.group(3)
+            selector = remove_extra_slashes(selector)
+            page_selectors.append(selector)
+            times = data.group(4)
+            comments = data.group(5)
+            command = '''%sself.press_%s_arrow(%s, %s)%s''' % (
+                whitespace, arrow, selector, times, comments)
+            if selector_dict:
+                if add_comments:
+                    comments = "  # %s" % selector
+                selector = optimize_selector(selector)
+                if selector in selector_dict.keys():
+                    selector_object = selector_dict[selector]
+                    changed.append(selector_object.split('.')[0])
+                    command = '''%sself.press_%s_arrow(%s, %s)%s''' % (
+                        whitespace, arrow, selector_object, times, comments)
+            if object_dict:
+                if not add_comments:
+                    comments = ""
+                object_name = selector
+                if object_name in object_dict.keys():
+                    selector_object = object_dict[object_name]
+                    changed.append(object_name.split('.')[0])
+                    command = '''%sself.press_%s_arrow(%s, %s)%s''' % (
+                        whitespace, arrow, selector_object, times, comments)
+            seleniumbase_lines.append(command)
+            continue
+
         # Handle self.assert_text(TEXT, SELECTOR)
         if not object_dict:
             data = re.match(
@@ -884,7 +1100,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.assert_text'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S\s]+),\s?([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -925,7 +1141,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.assert_exact_text'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S\s]+),\s?([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -966,7 +1182,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.find_text'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S\s]+),\s?([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -1007,7 +1223,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)(\S*)\sself\.is_text_(\S*)'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\):([\S\s]*)'''
+                r'''\(([\S\s]+),\s?([\S]+)\):([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -1052,7 +1268,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.wait_for_text'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S\s]+),\s?([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -1093,7 +1309,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.wait_for_text_visible'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S\s]+),\s?([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -1134,7 +1350,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)(\S*)\sself\.is_element_(\S*)'''
-                r'''\(([\S\s]+)\):([\S\s]*)'''
+                r'''\(([\S]+)\):([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -1169,6 +1385,130 @@ def process_test_file(
             seleniumbase_lines.append(command)
             continue
 
+        # Handle if/elif self.is_selected(SELECTOR):
+        if not object_dict:
+            data = re.match(
+                r'''^(\s*)(\S*)\sself\.is_selected'''
+                r'''\((r?['"][\S\s]+['"])\):([\S\s]*)'''
+                r'''$''', line)
+        else:
+            data = re.match(
+                r'''^(\s*)(\S*)\sself\.is_selected'''
+                r'''\(([\S]+)\):([\S\s]*)'''
+                r'''$''', line)
+        if data:
+            whitespace = data.group(1)
+            if_type = data.group(2)
+            selector = '%s' % data.group(3)
+            selector = remove_extra_slashes(selector)
+            page_selectors.append(selector)
+            comments = data.group(4)
+            command = '''%s%s self.is_selected(%s):%s''' % (
+                whitespace, if_type, selector, comments)
+            if selector_dict:
+                if add_comments:
+                    comments = "  # %s" % selector
+                selector = optimize_selector(selector)
+                if selector in selector_dict.keys():
+                    selector_object = selector_dict[selector]
+                    changed.append(selector_object.split('.')[0])
+                    command = '''%s%s self.is_selected(%s):%s''' % (
+                        whitespace, if_type, selector_object, comments)
+            if object_dict:
+                if not add_comments:
+                    comments = ""
+                object_name = selector
+                if object_name in object_dict.keys():
+                    selector_object = object_dict[object_name]
+                    changed.append(object_name.split('.')[0])
+                    command = '''%s%s self.is_selected(%s):%s''' % (
+                        whitespace, if_type, selector_object, comments)
+            seleniumbase_lines.append(command)
+            continue
+
+        # Handle self.assert*(self.is_selected(SELECTOR))
+        if not object_dict:
+            data = re.match(
+                r'''^(\s*)self\.assert(\S*)\(self\.is_selected'''
+                r'''\((r?['"][\S\s]+['"])\)\)([\S\s]*)'''
+                r'''$''', line)
+        else:
+            data = re.match(
+                r'''^(\s*)self\.assert(\S*)\(self\.is_selected'''
+                r'''\(([\S]+)\)\)([\S\s]*)'''
+                r'''$''', line)
+        if data:
+            whitespace = data.group(1)
+            a_type = data.group(2)
+            selector = '%s' % data.group(3)
+            selector = remove_extra_slashes(selector)
+            page_selectors.append(selector)
+            comments = data.group(4)
+            command = '''%sself.assert%s(self.is_selected(%s))%s''' % (
+                whitespace, a_type, selector, comments)
+            if selector_dict:
+                if add_comments:
+                    comments = "  # %s" % selector
+                selector = optimize_selector(selector)
+                if selector in selector_dict.keys():
+                    selector_object = selector_dict[selector]
+                    changed.append(selector_object.split('.')[0])
+                    command = '''%sself.assert%s(self.is_selected(%s))%s''' % (
+                        whitespace, a_type, selector_object, comments)
+            if object_dict:
+                if not add_comments:
+                    comments = ""
+                object_name = selector
+                if object_name in object_dict.keys():
+                    selector_object = object_dict[object_name]
+                    changed.append(object_name.split('.')[0])
+                    command = '''%sself.assert%s(self.is_selected(%s))%s''' % (
+                        whitespace, a_type, selector_object, comments)
+            seleniumbase_lines.append(command)
+            continue
+
+        # Handle self.assert*(self.is_element_*(SELECTOR))
+        if not object_dict:
+            data = re.match(
+                r'''^(\s*)self\.assert(\S*)\(self\.is_element_(\S*)'''
+                r'''\((r?['"][\S\s]+['"])\)\)([\S\s]*)'''
+                r'''$''', line)
+        else:
+            data = re.match(
+                r'''^(\s*)self\.assert(\S*)\(self\.is_element_(\S*)'''
+                r'''\(([\S]+)\)\)([\S\s]*)'''
+                r'''$''', line)
+        if data:
+            whitespace = data.group(1)
+            a_type = data.group(2)
+            v_type = data.group(3)
+            selector = '%s' % data.group(4)
+            selector = remove_extra_slashes(selector)
+            page_selectors.append(selector)
+            comments = data.group(5)
+            command = '''%sself.assert%s(self.is_element_%s(%s))%s''' % (
+                whitespace, a_type, v_type, selector, comments)
+            if selector_dict:
+                if add_comments:
+                    comments = "  # %s" % selector
+                selector = optimize_selector(selector)
+                if selector in selector_dict.keys():
+                    selector_object = selector_dict[selector]
+                    changed.append(selector_object.split('.')[0])
+                    command = '%sself.assert%s(self.is_element_%s(%s))%s' % (
+                        whitespace, a_type, v_type, selector_object, comments)
+            if object_dict:
+                if not add_comments:
+                    comments = ""
+                object_name = selector
+                if object_name in object_dict.keys():
+                    selector_object = object_dict[object_name]
+                    changed.append(object_name.split('.')[0])
+                    command = '%sself.assert%s(self.is_element_%s(%s))%s' % (
+                        whitespace, a_type, v_type, selector_object, comments)
+            seleniumbase_lines.append(command)
+            continue
+
         # Handle VAR = self.get_attribute(SELECTOR, ATTRIBUTE)
         if not object_dict:
             data = re.match(
@@ -1178,7 +1518,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)(\S*)\s?=\s?self\.get_attribute'''
-                r'''\(([\S\s]+),\s?(['"][\S\s]+['"])\)([\S\s]*)'''
+                r'''\(([\S]+),\s?(['"][\S\s]+['"])\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -1222,7 +1562,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)(\S*)\s?=\s?self\.get_text'''
-                r'''\(([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -1263,7 +1603,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)if\s(\S*\s?\S*)\sin\s?self\.get_text'''
-                r'''\(([\S\s]+)\):([\S\s]*)'''
+                r'''\(([\S]+)\):([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)
@@ -1304,7 +1644,7 @@ def process_test_file(
         else:
             data = re.match(
                 r'''^(\s*)self\.select_option_by_(\S*)'''
-                r'''\(([\S\s]+),\s?([\S\s]+)\)([\S\s]*)'''
+                r'''\(([\S]+),\s?([\S\s]+)\)([\S\s]*)'''
                 r'''$''', line)
         if data:
             whitespace = data.group(1)

--- a/seleniumbase/console_scripts/run.py
+++ b/seleniumbase/console_scripts/run.py
@@ -172,7 +172,7 @@ def show_mkfile_usage():
     print("          If the file already exists, an error is raised.")
     print("          By default, uses English mode and creates a")
     print("          boilerplate with the 5 most common SeleniumBase")
-    print('          methods, which are "open", "click", "update_text",')
+    print('          methods, which are "open", "type", "click",')
     print('          "assert_element", and "assert_text". If using the')
     print('          basic boilerplate option, only the "open" method')
     print('          is included.')

--- a/seleniumbase/console_scripts/run.py
+++ b/seleniumbase/console_scripts/run.py
@@ -26,6 +26,7 @@ sbase grid-node start --hub=127.0.0.1
 
 import colorama
 import sys
+colorama.init(autoreset=True)
 
 
 def show_usage():
@@ -35,7 +36,6 @@ def show_usage():
     sc += ('    For info on all commands, type: "seleniumbase --help".\n')
     sc += (' * (Use "pytest" for running tests) *\n')
     if "linux" not in sys.platform:
-        colorama.init(autoreset=True)
         c1 = colorama.Fore.BLUE + colorama.Back.LIGHTCYAN_EX
         c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
         c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
@@ -52,7 +52,6 @@ def show_usage():
 def show_basic_usage():
     from seleniumbase.console_scripts import logo_helper
     seleniumbase_logo = logo_helper.get_seleniumbase_logo()
-    colorama.init(autoreset=True)
     print(seleniumbase_logo)
     print("%s" % get_version()[0:1])
     print("")
@@ -80,7 +79,6 @@ def show_basic_usage():
     sc += (' * (EXAMPLE: "sbase install chromedriver latest")  *\n')
     sc += ("")
     if "linux" not in sys.platform:
-        colorama.init(autoreset=True)
         c1 = colorama.Fore.BLUE + colorama.Back.LIGHTCYAN_EX
         c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
         cr = colorama.Style.RESET_ALL
@@ -90,7 +88,6 @@ def show_basic_usage():
 
 
 def show_install_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -125,7 +122,6 @@ def show_install_usage():
 
 
 def show_mkdir_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -147,7 +143,6 @@ def show_mkdir_usage():
 
 
 def show_mkfile_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -180,7 +175,6 @@ def show_mkfile_usage():
 
 
 def show_convert_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -200,7 +194,6 @@ def show_convert_usage():
 
 
 def show_print_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -219,7 +212,6 @@ def show_print_usage():
 
 
 def show_translate_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -255,7 +247,6 @@ def show_translate_usage():
 
 
 def show_extract_objects_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -273,7 +264,6 @@ def show_extract_objects_usage():
 
 
 def show_inject_objects_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -294,7 +284,6 @@ def show_inject_objects_usage():
 
 
 def show_objectify_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -318,7 +307,6 @@ def show_objectify_usage():
 
 
 def show_revert_objects_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -340,7 +328,6 @@ def show_revert_objects_usage():
 
 
 def show_encrypt_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -358,7 +345,6 @@ def show_encrypt_usage():
 
 
 def show_decrypt_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -376,7 +362,6 @@ def show_decrypt_usage():
 
 
 def show_download_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -393,7 +378,6 @@ def show_download_usage():
 
 
 def show_grid_hub_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -421,7 +405,6 @@ def show_grid_hub_usage():
 
 
 def show_grid_node_usage():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     cr = colorama.Style.RESET_ALL
@@ -461,7 +444,6 @@ def show_version_info():
 
 
 def show_options():
-    colorama.init(autoreset=True)
     c1 = colorama.Fore.BLUE + colorama.Back.LIGHTCYAN_EX
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
@@ -518,7 +500,6 @@ def show_options():
 
 
 def show_detailed_help():
-    colorama.init(autoreset=True)
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
     c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
     c6 = colorama.Back.CYAN
@@ -590,7 +571,6 @@ def main():
     elif command == "print":
         if len(command_args) >= 1:
             if sys.version_info[0] == 2:
-                colorama.init(autoreset=True)
                 c5 = colorama.Fore.RED + colorama.Back.LIGHTYELLOW_EX
                 cr = colorama.Style.RESET_ALL
                 msg = '"sbase print" does NOT support Python 2! '
@@ -606,7 +586,6 @@ def main():
     elif command == "translate":
         if len(command_args) >= 1:
             if sys.version_info[0] == 2:
-                colorama.init(autoreset=True)
                 c5 = colorama.Fore.RED + colorama.Back.LIGHTYELLOW_EX
                 cr = colorama.Style.RESET_ALL
                 msg = "The SeleniumBase Translator does NOT support Python 2!"

--- a/seleniumbase/console_scripts/sb_mkfile.py
+++ b/seleniumbase/console_scripts/sb_mkfile.py
@@ -24,7 +24,7 @@ Output:
     If the file already exists, an error is raised.
     By default, uses English mode and creates a
     boilerplate with the 5 most common SeleniumBase
-    methods, which are "open", "click", "update_text",
+    methods, which are "open", "type", "click",
     "assert_element", and "assert_text". If using the
     basic boilerplate option, only the "open" method
     is included.
@@ -56,7 +56,7 @@ def invalid_run_command(msg=None):
     exp += "          If the file already exists, an error is raised.\n"
     exp += "          By default, uses English mode and creates a\n"
     exp += "          boilerplate with the 5 most common SeleniumBase\n"
-    exp += '          methods, which are "open", "click", "update_text",\n'
+    exp += '          methods, which are "open", "type", "click",\n'
     exp += '          "assert_element", and "assert_text". If using the\n'
     exp += '          basic boilerplate option, only the "open" method\n'
     exp += '          is included.\n'

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.49.14',
+    version='1.49.15',
     description='Web Automation and Test Framework - https://seleniumbase.io',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup(
         'pyotp==2.4.0',
         'boto==2.49.0',
         'cffi==1.14.2',
-        'rich==6.2.0;python_version>="3.6" and python_version<"4.0"',
+        'rich==7.0.0;python_version>="3.6" and python_version<"4.0"',
         'flake8==3.7.9;python_version<"3.5"',
         'flake8==3.8.3;python_version>="3.5"',
         'pyflakes==2.1.1;python_version<"3.5"',


### PR DESCRIPTION
### Update the console scripts' tools for generating page objects
* Update the console scripts tool for generating page objects
* Also optimize ``colorama`` / speed up console scripts output
* Also update the Python ``rich`` requirement to version ``7.0.0``

--------

#### Summary of the console scripts' tools for generating page objects:

```bash
  ** extract-objects **

  Usage:
           seleniumbase extract-objects [SELENIUMBASE_PYTHON_FILE]
           OR:    sbase extract-objects [SELENIUMBASE_PYTHON_FILE]
  Output:
           Creates page objects based on selectors found in a
           seleniumbase Python file and saves those objects to the
           "page_objects.py" file in the same folder as the tests.

  ** inject-objects **

  Usage:
           seleniumbase inject-objects [SELENIUMBASE_PYTHON_FILE]
           OR:    sbase inject-objects [SELENIUMBASE_PYTHON_FILE]
  Options:
           -c, --comments  (Add object selectors to the comments.)
                           (Default: No added comments.)
  Output:
           Takes the page objects found in the "page_objects.py"
           file and uses those to replace matching selectors in
           the selected seleniumbase Python file.

  ** objectify **

  Usage:
           seleniumbase objectify [SELENIUMBASE_PYTHON_FILE]
           OR:    sbase objectify [SELENIUMBASE_PYTHON_FILE]
  Options:
           -c, --comments  (Add object selectors to the comments.)
                           (Default: No added comments.)
  Output:
           A modified version of the file where the selectors
           have been replaced with variable names defined in
           "page_objects.py", supporting the Page Object Pattern.

           (seleniumbase "objectify" has the same outcome as
            combining "extract-objects" with "inject-objects")

  ** revert-objects **

  Usage:
           seleniumbase revert-objects [SELENIUMBASE_PYTHON_FILE]
           OR:    sbase revert-objects [SELENIUMBASE_PYTHON_FILE]
  Options:
           -c, --comments  (Keep existing comments for the lines.)
                           (Default: No comments are kept.)
  Output:
           Reverts the changes made by "seleniumbase objectify" or
           "seleniumbase inject-objects" when run against a
           seleniumbase Python file. Objects will get replaced by
           selectors stored in the "page_objects.py" file.

```
