### PR TITLE
Convert int/float inputs to strings before typing text

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ coverage==5.3
 brython==3.8.10
 pyotp==2.4.0
 boto==2.49.0
-cffi==1.14.2
+cffi==1.14.3
 rich==7.0.0;python_version>="3.6" and python_version<"4.0"
 flake8==3.7.9;python_version<"3.5"
 flake8==3.8.3;python_version>="3.5"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -377,6 +377,8 @@ class BaseCase(unittest.TestCase):
         if not self.demo_mode and not self.slow_mode:
             self.__scroll_to_element(element, selector, by)
         pre_action_url = self.driver.current_url
+        if type(text) is int or type(text) is float:
+            text = str(text)
         try:
             if not text.endswith('\n'):
                 element.send_keys(text)

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup(
         'brython==3.8.10',
         'pyotp==2.4.0',
         'boto==2.49.0',
-        'cffi==1.14.2',
+        'cffi==1.14.3',
         'rich==7.0.0;python_version>="3.6" and python_version<"4.0"',
         'flake8==3.7.9;python_version<"3.5"',
         'flake8==3.8.3;python_version>="3.5"',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.49.16',
+    version='1.49.17',
     description='Web Automation and Test Framework - https://seleniumbase.io',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Convert int/float inputs to strings before typing text
* Convert integer inputs to strings before typing text
* Also update the ``cffi`` requirement to ``cffi==1.14.3``

The fix for this is simple:

```python
if type(text) is int or type(text) is float:
    text = str(text)
```

This conversion is necessary to prevent errors from occurring in:

```python
if not text.endswith('\n'):
    element.send_keys(text)
else:
    element.send_keys(text[:-1])
    element.send_keys(Keys.RETURN)
```

Most text-typing methods already fixed this. Now they all fix it.

Fixed methods:

```python
self.add_text(selector, text)
self.send_keys(selector, text)  # Same as self.add_text()
```
