### PR TITLE
Backport a fix for older versions of Python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,9 +52,10 @@ ipython==5.10.0;python_version<"3.5"
 ipython==6.5.0;python_version>="3.5" and python_version<"3.6"
 ipython==7.16.1;python_version>="3.6" and python_version<"3.7"
 ipython==7.18.1;python_version>="3.7"
+colorama==0.4.3
+pathlib2>=2.3.5;python_version<"3.5"
 importlib-metadata==1.7.0
 virtualenv>=20.0.31
-colorama==0.4.3
 pymysql==0.10.1
 coverage==5.3
 brython==3.8.10

--- a/setup.py
+++ b/setup.py
@@ -146,9 +146,10 @@ setup(
         'ipython==6.5.0;python_version>="3.5" and python_version<"3.6"',
         'ipython==7.16.1;python_version>="3.6" and python_version<"3.7"',
         'ipython==7.18.1;python_version>="3.7"',
+        'colorama==0.4.3',
+        'pathlib2>=2.3.5;python_version<"3.5"',  # Sync with "virtualenv"
         'importlib-metadata==1.7.0',  # Must stay in sync with "virtualenv"
         'virtualenv>=20.0.31',  # Must stay in sync with "importlib-metadata"
-        'colorama==0.4.3',
         'pymysql==0.10.1',
         'coverage==5.3',
         'brython==3.8.10',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='seleniumbase',
-    version='1.49.20',
+    version='1.49.21',
     description='A complete framework for Web-UI testing | seleniumbase.io',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Backport a fix for older versions of Python
* ``pathlib2>=2.3.5;python_version<"3.5"``

This will fix the following issue on systems running an older version of Python: 
``error: pathlib2 2.3.2 is installed but pathlib2<3,>=2.3.3; python_version < "3.4" and sys_platform != "win32" is required by set(['virtualenv'])``