### PR TITLE
Small update to "wait_for_ready_state_complete()"

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.50.2"
+__version__ = "1.50.3"

--- a/seleniumbase/fixtures/js_utils.py
+++ b/seleniumbase/fixtures/js_utils.py
@@ -25,13 +25,6 @@ def wait_for_ready_state_complete(driver, timeout=settings.EXTREME_TIMEOUT):
     for x in range(int(timeout * 10)):
         shared_utils.check_if_time_limit_exceeded()
         try:
-            # If there's an alert, skip
-            driver.switch_to.alert
-            return
-        except Exception:
-            # If there's no alert, continue
-            pass
-        try:
             ready_state = driver.execute_script("return document.readyState")
         except WebDriverException:
             # Bug fix for: [Permission denied to access property "document"]


### PR DESCRIPTION
### Small update to ``wait_for_ready_state_complete()``

(This completes the change from the previous release)

A change was made that may impact tests that have alert pop-ups when opening a new page via open or click. This was done to prevent an issue that could occur if developers set custom implicit waits in their code.
The method: wait_for_ready_state_complete() (which SeleniumBase uses for smart-waiting) runs some JavaScript to check that the readyState of the page is "complete" before moving on, but that automatically dismisses alert pop-ups that may appear. If you are expecting to deal with an alert pop-up after going to a new page via self.open(URL) or self.click(SELECTOR), consider using self.driver.get(URL) or self.find_element(SELECTOR).click() instead, which won't use the SeleniumBase smart-waiting that may dismiss alert pop-ups before the user can call custom code to interact with them, such as self.wait_for_and_accept_alert() or self.wait_for_and_dismiss_alert().