### PR TITLE
Driver updates and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ geckodriver.exe
 msedgedriver.exe
 operadriver.exe
 
+# msedgedriver requirements
+libc++.dylib
+
 # Logs
 logs
 latest_logs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-regex>=2020.11.11
+regex>=2020.11.13
 tqdm>=4.51.0
 livereload==2.6.3;python_version>="3.6"
 Markdown==3.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ parso==0.7.1
 jedi==0.17.2
 idna==2.10
 chardet==3.0.4
-urllib3==1.26.1
+urllib3==1.26.2
 requests==2.25.0
 selenium==3.141.0
 msedge-selenium-tools==3.141.2

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.50.5"
+__version__ = "1.50.6"

--- a/seleniumbase/console_scripts/sb_install.py
+++ b/seleniumbase/console_scripts/sb_install.py
@@ -410,13 +410,19 @@ def main(override=None):
             print("")
         elif name == "edgedriver" or name == "msedgedriver":
             if "darwin" in sys_plat or "linux" in sys_plat:
-                # Was expecting to be on a Windows OS at this point
-                raise Exception("Unexpected file format for msedgedriver!")
-            expected_contents = (['Driver_Notes/',
-                                  'Driver_Notes/credits.html',
-                                  'Driver_Notes/LICENSE',
-                                  'msedgedriver.exe'])
-            if len(contents) > 4:
+                # Mac / Linux
+                expected_contents = (['Driver_Notes/',
+                                      'Driver_Notes/LICENSE',
+                                      'Driver_Notes/credits.html',
+                                      'msedgedriver',
+                                      'libc++.dylib'])
+            else:
+                # Windows
+                expected_contents = (['Driver_Notes/',
+                                      'Driver_Notes/credits.html',
+                                      'Driver_Notes/LICENSE',
+                                      'msedgedriver.exe'])
+            if len(contents) > 5:
                 raise Exception("Unexpected content in EdgeDriver Zip file!")
             for content in contents:
                 if content not in expected_contents:
@@ -430,11 +436,20 @@ def main(override=None):
                 # Remove existing version if exists
                 str_name = str(f_name)
                 new_file = downloads_folder + '/' + str_name
-                if str_name == "msedgedriver.exe":
-                    driver_file = str_name
-                    driver_path = new_file
-                    if os.path.exists(new_file):
-                        os.remove(new_file)
+                if "darwin" in sys_plat or "linux" in sys_plat:
+                    # Mac / Linux
+                    if str_name == "msedgedriver":
+                        driver_file = str_name
+                        driver_path = new_file
+                        if os.path.exists(new_file):
+                            os.remove(new_file)
+                else:
+                    # Windows
+                    if str_name == "msedgedriver.exe":
+                        driver_file = str_name
+                        driver_path = new_file
+                        if os.path.exists(new_file):
+                            os.remove(new_file)
             if not driver_file or not driver_path:
                 raise Exception("msedgedriver missing from Zip file!")
             print('Extracting %s from %s ...' % (contents, file_name))

--- a/seleniumbase/console_scripts/sb_install.py
+++ b/seleniumbase/console_scripts/sb_install.py
@@ -18,7 +18,7 @@ Example:
         sbase install chromedriver latest
         sbase install chromedriver -p
         sbase install chromedriver latest -p
-        sbase install edgedriver 85.0.564.68
+        sbase install edgedriver 86.0.622.69
 Output:
         Installs the chosen webdriver to seleniumbase/drivers/
         (chromedriver is required for Chrome automation)
@@ -42,8 +42,8 @@ urllib3.disable_warnings()
 DRIVER_DIR = os.path.dirname(os.path.realpath(drivers.__file__))
 LOCAL_PATH = "/usr/local/bin/"  # On Mac and Linux systems
 DEFAULT_CHROMEDRIVER_VERSION = "2.44"  # (Specify "latest" to get the latest)
-DEFAULT_GECKODRIVER_VERSION = "v0.27.0"
-DEFAULT_EDGEDRIVER_VERSION = "85.0.564.44"  # (Looks for LATEST_STABLE first)
+DEFAULT_GECKODRIVER_VERSION = "v0.28.0"
+DEFAULT_EDGEDRIVER_VERSION = "86.0.622.69"  # (Looks for LATEST_STABLE first)
 DEFAULT_OPERADRIVER_VERSION = "v.84.0.4147.89"
 
 

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -312,7 +312,7 @@ def _create_firefox_profile(
     profile.set_preference("browser.privatebrowsing.autostart", True)
     profile.set_preference("devtools.errorconsole.enabled", False)
     profile.set_preference("dom.webnotifications.enabled", False)
-    profile.set_preference("dom.disable_beforeunload", True)
+    profile.set_preference("dom.disable_beforeunload", False)
     profile.set_preference("browser.contentblocking.database.enabled", False)
     profile.set_preference("extensions.allowPrivateBrowsingByDefault", True)
     profile.set_preference("extensions.PrivateBrowsing.notification", False)

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         'jedi==0.17.2',  # The last version for Python 2 and 3.5
         'idna==2.10',  # Must stay in sync with "requests"
         'chardet==3.0.4',  # Must stay in sync with "requests"
-        'urllib3==1.26.1',  # Must stay in sync with "requests"
+        'urllib3==1.26.2',  # Must stay in sync with "requests"
         'requests==2.25.0',
         'selenium==3.141.0',
         'msedge-selenium-tools==3.141.2',


### PR DESCRIPTION
### Driver updates and more
* Update default edgedriver and geckodriver versions.
* Handle the new zip format for edgedriver packaging.
* Update Firefox preferences.
* Set ``urllib3`` version to ``1.26.2``.