### PR TITLE
Add the "--remote-debug" option to use Chrome's Remote Debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,5 +134,4 @@ downloaded_files
 archived_files
 assets
 temp
-temp*
 node_modules

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 <link rel="icon" href="https://seleniumbase.io/img/logo3a.png" />
 
 <p align="center"><a href="https://github.com/seleniumbase/SeleniumBase/">
-<img src="https://seleniumbase.io/cdn/img/super_logo_sb.png" alt="SeleniumBase" title="SeleniumBase" width="300" />
-</a></p>
+<img src="https://seleniumbase.io/cdn/img/sb_logo_b.png" alt="SeleniumBase" title="SeleniumBase" width="360" /></a></p>
 
 <!-- View on GitHub -->
 <p align="center"><a href="https://github.com/seleniumbase/SeleniumBase/releases">

--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ SeleniumBase provides additional ``pytest`` command-line options for tests:
 --enable-ws  # (Enable Web Security on Chromium-based browsers.)
 --enable-sync  # (Enable "Chrome Sync".)
 --use-auto-ext  # (Use Chrome's automation extension.)
+--remote-debug  # (Enable Chrome's Remote Debugger on http://localhost:9222)
 --swiftshader  # (Use Chrome's "--use-gl=swiftshader" feature.)
 --incognito  #  (Enable Chrome's Incognito mode.)
 --guest  # (Enable Chrome's Guest mode.)

--- a/examples/ReadMe.md
+++ b/examples/ReadMe.md
@@ -1,4 +1,4 @@
-<img src="https://seleniumbase.io/cdn/img/sb_logo_b.png" title="SeleniumBase" width="300" />
+<img src="https://seleniumbase.io/cdn/img/super_logo_sb.png" title="SeleniumBase" width="300" />
 
 <h2><img src="https://seleniumbase.io/img/logo3a.png" title="SeleniumBase" width="32" /> Running Example Tests:</h2>
 

--- a/examples/raw_parameter_script.py
+++ b/examples/raw_parameter_script.py
@@ -71,6 +71,7 @@ except (ImportError, ValueError):
     sb.demo_sleep = 1
     sb.message_duration = 2
     sb.block_images = False
+    sb.remote_debug = False
     sb.settings_file = None
     sb.user_data_dir = None
     sb.proxy_string = None

--- a/examples/test_parse_soup.py
+++ b/examples/test_parse_soup.py
@@ -1,15 +1,25 @@
+import re
 from seleniumbase import BaseCase
 
 
 class MyTestClass(BaseCase):
 
-    def test_tinymce(self):
+    def click_menu_item(self, text):
+        # Use BeautifulSoup to parse the selector ID from element text.
+        # Then click on the element with the ID.
+        # (This is useful when the selector ID is auto-generated.)
+        pattern = re.compile(text)
+        soup = self.get_beautiful_soup()
+        the_id = soup.find(text=pattern).parent.parent.attrs["id"]
+        self.click("#%s" % the_id)
+
+    def test_beautiful_soup_and_tinymce(self):
         self.open("https://seleniumbase.io/tinymce/")
         self.wait_for_element("div.mce-container-body")
-        self.click('span:contains("File")')
-        self.click('span:contains("New document")')
-        self.click('span:contains("Paragraph")')
-        self.click('span:contains("Heading 2")')
+        self.click_menu_item("File")
+        self.click_menu_item("New document")
+        self.click_menu_item("Paragraph")
+        self.click_menu_item("Heading 2")
         self.switch_to_frame("iframe")
         self.add_text("#tinymce", "Automate anything with SeleniumBase!\n")
         self.switch_to_default_content()
@@ -21,7 +31,7 @@ class MyTestClass(BaseCase):
         self.click("h2")
         self.switch_to_default_content()
         self.post_message("Automate anything with SeleniumBase!")
-        self.click('span:contains("File")')
-        self.click('span:contains("Preview")')
+        self.click_menu_item("File")
+        self.click_menu_item("Preview")
         self.switch_to_frame('iframe[sandbox="allow-scripts"]')
         self.post_message("Learn SeleniumBase Today!")

--- a/help_docs/ReadMe.md
+++ b/help_docs/ReadMe.md
@@ -69,7 +69,7 @@
 <h3>Demo Pages / Web Examples</h3>
 
 <div><a href="https://seleniumbase.io/demo_page"><b>Demo Page / Demo Site</b></a></div>
-<div><a href="https://seleniumbase.io/other/tinymce"><b>TinyMCE Demo Page</b></a></div>
+<div><a href="https://seleniumbase.io/tinymce/"><b>TinyMCE Demo Page</b></a></div>
 <div><a href="https://seleniumbase.io/devices/"><b>Virtual Device Farm</b></a></div>
 <div><a href="https://seleniumbase.io/error_page/"><b>Error Page for Tests</b></a></div>
 <div><a href="https://seleniumbase.io/other/presenter.html"><b>Presenter Demo</b></a></div>

--- a/help_docs/customizing_test_runs.md
+++ b/help_docs/customizing_test_runs.md
@@ -128,6 +128,7 @@ SeleniumBase provides additional ``pytest`` command-line options for tests:
 --enable-ws  # (Enable Web Security on Chromium-based browsers.)
 --enable-sync  # (Enable "Chrome Sync".)
 --use-auto-ext  # (Use Chrome's automation extension.)
+--remote-debug  # (Enable Chrome's Remote Debugger on http://localhost:9222)
 --swiftshader  # (Use Chrome's "--use-gl=swiftshader" feature.)
 --incognito  #  (Enable Chrome's Incognito mode.)
 --guest  # (Enable Chrome's Guest mode.)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pip>=20.3
+pip>=20.3.1
 packaging>=20.7
 setuptools>=44.1.1;python_version<"3.5"
 setuptools>=50.3.2;python_version>="3.5"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.50.16"
+__version__ = "1.50.17"

--- a/seleniumbase/config/proxy_list.py
+++ b/seleniumbase/config/proxy_list.py
@@ -15,13 +15,15 @@ Format of PROXY_LIST server entries:
 Example proxies in PROXY_LIST below are not guaranteed to be active or secure.
 If you don't already have a proxy server to connect to,
 you can try finding one from one of following sites:
+* https://bit.ly/36GtZa1
 * https://www.us-proxy.org/
 * https://hidemy.name/en/proxy-list/
+* http://free-proxy.cz/en/proxylist/country/all/https/ping/all
 """
 
 PROXY_LIST = {
-    "example1": "134.209.128.61:3128",  # (Example) - set your own proxy here
-    "example2": "165.227.83.185:3128",  # (Example) - set your own proxy here
+    "example1": "152.26.66.140:3128",  # (Example) - set your own proxy here
+    "example2": "64.235.204.107:8080",  # (Example) - set your own proxy here
     "example3": "82.200.233.4:3128",  # (Example) - set your own proxy here
     "proxy1": None,
     "proxy2": None,

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -132,8 +132,9 @@ def _set_chrome_options(
         browser_name, downloads_path, headless, locale_code,
         proxy_string, proxy_auth, proxy_user, proxy_pass,
         user_agent, disable_csp, enable_ws, enable_sync, use_auto_ext,
-        no_sandbox, disable_gpu, incognito, guest_mode, devtools, swiftshader,
-        block_images, user_data_dir, extension_zip, extension_dir, servername,
+        no_sandbox, disable_gpu, incognito, guest_mode,
+        devtools, remote_debug, swiftshader, block_images,
+        user_data_dir, extension_zip, extension_dir, servername,
         mobile_emulator, device_width, device_height, device_pixel_ratio):
     chrome_options = webdriver.ChromeOptions()
     prefs = {
@@ -283,6 +284,11 @@ def _set_chrome_options(
     else:
         # Opera Chromium only!
         chrome_options.add_argument("--allow-elevated-browser")
+    if remote_debug:
+        # To access the Remote Debugger, go to: http://localhost:9222
+        # while a Chromium driver is running.
+        # Info: https://chromedevtools.github.io/devtools-protocol/
+        chrome_options.add_argument('--remote-debugging-port=9222')
     if swiftshader:
         chrome_options.add_argument("--use-gl=swiftshader")
     else:
@@ -418,9 +424,10 @@ def get_driver(browser_name, headless=False, locale_code=None,
                cap_file=None, cap_string=None,
                disable_csp=None, enable_ws=None, enable_sync=None,
                use_auto_ext=None, no_sandbox=None, disable_gpu=None,
-               incognito=None, guest_mode=None, devtools=None,
-               swiftshader=None, block_images=None, user_data_dir=None,
-               extension_zip=None, extension_dir=None,
+               incognito=None, guest_mode=None,
+               devtools=None, remote_debug=None,
+               swiftshader=None, block_images=None,
+               user_data_dir=None, extension_zip=None, extension_dir=None,
                test_id=None, mobile_emulator=False, device_width=None,
                device_height=None, device_pixel_ratio=None):
     proxy_auth = False
@@ -458,16 +465,17 @@ def get_driver(browser_name, headless=False, locale_code=None,
             proxy_string, proxy_auth, proxy_user, proxy_pass, user_agent,
             cap_file, cap_string, disable_csp, enable_ws, enable_sync,
             use_auto_ext, no_sandbox, disable_gpu, incognito, guest_mode,
-            devtools, swiftshader, block_images, user_data_dir,
-            extension_zip, extension_dir, test_id,
+            devtools, remote_debug, swiftshader, block_images,
+            user_data_dir, extension_zip, extension_dir, test_id,
             mobile_emulator, device_width, device_height, device_pixel_ratio)
     else:
         return get_local_driver(
             browser_name, headless, locale_code, servername,
             proxy_string, proxy_auth, proxy_user, proxy_pass, user_agent,
-            disable_csp, enable_ws, enable_sync, use_auto_ext, no_sandbox,
-            disable_gpu, incognito, guest_mode, devtools, swiftshader,
-            block_images, user_data_dir, extension_zip, extension_dir,
+            disable_csp, enable_ws, enable_sync,
+            use_auto_ext, no_sandbox, disable_gpu, incognito, guest_mode,
+            devtools, remote_debug, swiftshader, block_images,
+            user_data_dir, extension_zip, extension_dir,
             mobile_emulator, device_width, device_height, device_pixel_ratio)
 
 
@@ -476,7 +484,7 @@ def get_remote_driver(
         proxy_string, proxy_auth, proxy_user, proxy_pass, user_agent,
         cap_file, cap_string, disable_csp, enable_ws, enable_sync,
         use_auto_ext, no_sandbox, disable_gpu, incognito, guest_mode,
-        devtools, swiftshader, block_images,
+        devtools, remote_debug, swiftshader, block_images,
         user_data_dir, extension_zip, extension_dir, test_id,
         mobile_emulator, device_width, device_height, device_pixel_ratio):
     downloads_path = download_helper.get_downloads_folder()
@@ -508,8 +516,9 @@ def get_remote_driver(
             browser_name, downloads_path, headless, locale_code,
             proxy_string, proxy_auth, proxy_user, proxy_pass, user_agent,
             disable_csp, enable_ws, enable_sync, use_auto_ext, no_sandbox,
-            disable_gpu, incognito, guest_mode, devtools, swiftshader,
-            block_images, user_data_dir, extension_zip, extension_dir,
+            disable_gpu, incognito, guest_mode,
+            devtools, remote_debug, swiftshader, block_images,
+            user_data_dir, extension_zip, extension_dir,
             servername, mobile_emulator,
             device_width, device_height, device_pixel_ratio)
         capabilities = chrome_options.to_capabilities()
@@ -635,8 +644,9 @@ def get_local_driver(
         browser_name, headless, locale_code, servername,
         proxy_string, proxy_auth, proxy_user, proxy_pass, user_agent,
         disable_csp, enable_ws, enable_sync, use_auto_ext, no_sandbox,
-        disable_gpu, incognito, guest_mode, devtools, swiftshader,
-        block_images, user_data_dir, extension_zip, extension_dir,
+        disable_gpu, incognito, guest_mode,
+        devtools, remote_debug, swiftshader, block_images,
+        user_data_dir, extension_zip, extension_dir,
         mobile_emulator, device_width, device_height, device_pixel_ratio):
     '''
     Spins up a new web browser and returns the driver.
@@ -727,9 +737,9 @@ def get_local_driver(
                 browser_name, downloads_path, headless, locale_code,
                 proxy_string, proxy_auth, proxy_user, proxy_pass, user_agent,
                 disable_csp, enable_ws, enable_sync, use_auto_ext,
-                no_sandbox, disable_gpu, incognito, guest_mode, devtools,
-                swiftshader, block_images, user_data_dir,
-                extension_zip, extension_dir, servername,
+                no_sandbox, disable_gpu, incognito, guest_mode,
+                devtools, remote_debug, swiftshader, block_images,
+                user_data_dir, extension_zip, extension_dir, servername,
                 mobile_emulator, device_width, device_height,
                 device_pixel_ratio)
             if LOCAL_EDGEDRIVER and os.path.exists(LOCAL_EDGEDRIVER):
@@ -839,6 +849,11 @@ def get_local_driver(
             if user_agent:
                 edge_options.add_argument("--user-agent=%s" % user_agent)
             edge_options.add_argument("--no-sandbox")
+            if remote_debug:
+                # To access the Remote Debugger, go to: http://localhost:9222
+                # while a Chromium driver is running.
+                # Info: https://chromedevtools.github.io/devtools-protocol/
+                edge_options.add_argument('--remote-debugging-port=9222')
             if swiftshader:
                 edge_options.add_argument("--use-gl=swiftshader")
             else:
@@ -868,9 +883,10 @@ def get_local_driver(
                 browser_name, downloads_path, headless, locale_code,
                 proxy_string, proxy_auth, proxy_user, proxy_pass, user_agent,
                 disable_csp, enable_ws, enable_sync, use_auto_ext,
-                no_sandbox, disable_gpu, incognito, guest_mode, devtools,
-                swiftshader, block_images, user_data_dir, extension_zip,
-                extension_dir, servername, mobile_emulator,
+                no_sandbox, disable_gpu, incognito, guest_mode,
+                devtools, remote_debug, swiftshader, block_images,
+                user_data_dir, extension_zip, extension_dir,
+                servername, mobile_emulator,
                 device_width, device_height, device_pixel_ratio)
             opera_options.headless = False  # No support for headless Opera
             return webdriver.Opera(options=opera_options)
@@ -887,9 +903,10 @@ def get_local_driver(
                 browser_name, downloads_path, headless, locale_code,
                 proxy_string, proxy_auth, proxy_user, proxy_pass, user_agent,
                 disable_csp, enable_ws, enable_sync, use_auto_ext,
-                no_sandbox, disable_gpu, incognito, guest_mode, devtools,
-                swiftshader, block_images, user_data_dir, extension_zip,
-                extension_dir, servername, mobile_emulator,
+                no_sandbox, disable_gpu, incognito, guest_mode,
+                devtools, remote_debug, swiftshader, block_images,
+                user_data_dir, extension_zip, extension_dir,
+                servername, mobile_emulator,
                 device_width, device_height, device_pixel_ratio)
             if LOCAL_CHROMEDRIVER and os.path.exists(LOCAL_CHROMEDRIVER):
                 try:

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -1782,7 +1782,8 @@ class BaseCase(unittest.TestCase):
                        switch_to=True, cap_file=None, cap_string=None,
                        disable_csp=None, enable_ws=None, enable_sync=None,
                        use_auto_ext=None, no_sandbox=None, disable_gpu=None,
-                       incognito=None, guest_mode=None, devtools=None,
+                       incognito=None, guest_mode=None,
+                       devtools=None, remote_debug=None,
                        swiftshader=None, block_images=None, user_data_dir=None,
                        extension_zip=None, extension_dir=None, is_mobile=False,
                        d_width=None, d_height=None, d_p_r=None):
@@ -1809,7 +1810,8 @@ class BaseCase(unittest.TestCase):
             incognito - the option to enable Chrome's Incognito mode (Chrome)
             guest - the option to enable Chrome's Guest mode (Chrome)
             devtools - the option to open Chrome's DevTools on start (Chrome)
-            swiftshader  the option to use "--use-gl=swiftshader" (Chrome-only)
+            remote_debug - the option to enable Chrome's Remote Debugger
+            swiftshader - the option to use Chrome's swiftshader (Chrome-only)
             block_images - the option to block images from loading (Chrome)
             user_data_dir - Chrome's User Data Directory to use (Chrome-only)
             extension_zip - A Chrome Extension ZIP file to use (Chrome-only)
@@ -1879,6 +1881,8 @@ class BaseCase(unittest.TestCase):
             guest_mode = self.guest_mode
         if devtools is None:
             devtools = self.devtools
+        if remote_debug is None:
+            remote_debug = self.remote_debug
         if swiftshader is None:
             swiftshader = self.swiftshader
         if block_images is None:
@@ -1927,6 +1931,7 @@ class BaseCase(unittest.TestCase):
                                                  incognito=incognito,
                                                  guest_mode=guest_mode,
                                                  devtools=devtools,
+                                                 remote_debug=remote_debug,
                                                  swiftshader=swiftshader,
                                                  block_images=block_images,
                                                  user_data_dir=user_data_dir,
@@ -6255,6 +6260,7 @@ class BaseCase(unittest.TestCase):
             self.incognito = sb_config.incognito
             self.guest_mode = sb_config.guest_mode
             self.devtools = sb_config.devtools
+            self.remote_debug = sb_config.remote_debug
             self.swiftshader = sb_config.swiftshader
             self.user_data_dir = sb_config.user_data_dir
             self.extension_zip = sb_config.extension_zip
@@ -6422,6 +6428,7 @@ class BaseCase(unittest.TestCase):
                                               incognito=self.incognito,
                                               guest_mode=self.guest_mode,
                                               devtools=self.devtools,
+                                              remote_debug=self.remote_debug,
                                               swiftshader=self.swiftshader,
                                               block_images=self.block_images,
                                               user_data_dir=self.user_data_dir,

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2939,21 +2939,28 @@ class BaseCase(unittest.TestCase):
         self.assertRaises(*args, **kwargs)
 
     def assert_title(self, title):
-        """ Asserts that the web page title matches the expected title. """
+        """ Asserts that the web page title matches the expected title.
+            When a web page initially loads, the title starts as the URL,
+            but then the title switches over to the actual page title.
+            A slow connection could delay the actual title from displaying. """
         self.wait_for_ready_state_complete()
         expected = title.strip()
         actual = self.get_page_title().strip()
+        error = (
+            "Expected page title [%s] does not match the actual title [%s]!")
         try:
-            self.assertEqual(expected, actual, "Expected page title [%s] "
-                             "does not match the actual page title [%s]!"
-                             "" % (expected, actual))
+            self.assertEqual(expected, actual, error % (expected, actual))
         except Exception:
             self.wait_for_ready_state_complete()
             self.sleep(settings.MINI_TIMEOUT)
-            actual = self.get_page_title()
-            self.assertEqual(expected, actual, "Expected page title [%s] "
-                             "does not match the actual page title [%s]!"
-                             "" % (expected, actual))
+            actual = self.get_page_title().strip()
+            try:
+                self.assertEqual(expected, actual, error % (expected, actual))
+            except Exception:
+                self.wait_for_ready_state_complete()
+                self.sleep(settings.MINI_TIMEOUT)
+                actual = self.get_page_title().strip()
+                self.assertEqual(expected, actual, error % (expected, actual))
         if self.demo_mode:
             a_t = "ASSERT TITLE"
             if self._language != "English":

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2570,10 +2570,10 @@ class BaseCase(unittest.TestCase):
 
     def get_beautiful_soup(self, source=None):
         """ BeautifulSoup is a toolkit for dissecting an HTML document
-            and extracting what you need. It's great for screen-scraping! """
+            and extracting what you need. It's great for screen-scraping!
+            See: https://www.crummy.com/software/BeautifulSoup/bs4/doc/ """
         from bs4 import BeautifulSoup
         if not source:
-            self.wait_for_ready_state_complete()
             source = self.get_page_source()
         soup = BeautifulSoup(source, "html.parser")
         return soup

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -52,6 +52,7 @@ def pytest_addoption(parser):
     --enable-ws  (Enable Web Security on Chromium-based browsers.)
     --enable-sync  (Enable "Chrome Sync".)
     --use-auto-ext  (Use Chrome's automation extension.)
+    --remote-debug  (Enable Chrome's Remote Debugger on http://localhost:9222)
     --swiftshader  (Use Chrome's "--use-gl=swiftshader" feature.)
     --incognito  (Enable Chrome's Incognito mode.)
     --guest  (Enable Chrome's Guest mode.)
@@ -413,6 +414,14 @@ def pytest_addoption(parser):
                      default=False,
                      help="""Using this enables the "Disable GPU" feature.
                           (This setting is now always enabled by default.)""")
+    parser.addoption('--remote_debug', '--remote-debug',
+                     action="store_true",
+                     dest='remote_debug',
+                     default=False,
+                     help="""This enables Chromium's remote debugger.
+                          To access the remote debugging interface, go to:
+                          http://localhost:9222 while Chromedriver is running.
+                          Info: chromedevtools.github.io/devtools-protocol/""")
     parser.addoption('--swiftshader',
                      action="store_true",
                      dest='swiftshader',
@@ -538,6 +547,7 @@ def pytest_configure(config):
     sb_config.use_auto_ext = config.getoption('use_auto_ext')
     sb_config.no_sandbox = config.getoption('no_sandbox')
     sb_config.disable_gpu = config.getoption('disable_gpu')
+    sb_config.remote_debug = config.getoption('remote_debug')
     sb_config.swiftshader = config.getoption('swiftshader')
     sb_config.incognito = config.getoption('incognito')
     sb_config.guest_mode = config.getoption('guest_mode')

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -42,6 +42,7 @@ class SeleniumBrowser(Plugin):
     --enable-ws  (Enable Web Security on Chromium-based browsers.)
     --enable-sync  (Enable "Chrome Sync".)
     --use-auto-ext  (Use Chrome's automation extension.)
+    --remote-debug  (Enable Chrome's Remote Debugger on http://localhost:9222)
     --swiftshader  (Use Chrome's "--use-gl=swiftshader" feature.)
     --incognito  (Enable Chrome's Incognito mode.)
     --guest  (Enable Chrome's Guest mode.)
@@ -324,6 +325,15 @@ class SeleniumBrowser(Plugin):
             help="""Using this enables the "Disable GPU" feature.
                     (This setting is now always enabled by default.)""")
         parser.add_option(
+            '--remote_debug', '--remote-debug',
+            action="store_true",
+            dest='remote_debug',
+            default=False,
+            help="""This enables Chromium's remote debugger.
+                    To access the remote debugging interface, go to:
+                    http://localhost:9222 while Chromedriver is running.
+                    Info: chromedevtools.github.io/devtools-protocol/""")
+        parser.add_option(
             '--swiftshader',
             action="store_true",
             dest='swiftshader',
@@ -423,6 +433,7 @@ class SeleniumBrowser(Plugin):
         test.test.use_auto_ext = self.options.use_auto_ext
         test.test.no_sandbox = self.options.no_sandbox
         test.test.disable_gpu = self.options.disable_gpu
+        test.text.remote_debug = self.options.remote_debug
         test.test.swiftshader = self.options.swiftshader
         test.test.incognito = self.options.incognito
         test.test.guest_mode = self.options.guest_mode

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=[
-        'pip>=20.3',
+        'pip>=20.3.1',
         'packaging>=20.7',
         'setuptools>=44.1.1;python_version<"3.5"',
         'setuptools>=50.3.2;python_version>="3.5"',


### PR DESCRIPTION
### Add the "--remote-debug" option to use Chrome's Remote Debugger
* Add the ``--remote-debug`` option to use Chromium's Remote Debugger (from the Chrome DevTools Protocol)
* Also upgrade "pip": ``pip>=20.3.1``
* Also make a few minor updates to ``assert_title()`` and ``get_beautiful_soup()``

See https://chromedevtools.github.io/devtools-protocol/ for more info on the Chrome DevTools Protocol.

When using ``--remote-debug`` on the command line with ``pytest``, you can access the Remote Debugger by going to: http://localhost:9222 while Chromedriver is running.
