### PR TITLE
Chrome extensions in Edge, Socks4/5 proxy support, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,16 +569,24 @@ pytest test_suite.py --alluredir=allure_results
 
 <h3><img src="https://seleniumbase.io/img/logo6.png" title="SeleniumBase" width="32" /> Using a Proxy Server:</h3>
 
-If you wish to use a proxy server for your browser tests (Chrome and Firefox only), you can add ``--proxy=IP_ADDRESS:PORT`` as an argument on the command-line.
+If you wish to use a proxy server for your browser tests (Chromium or Firefox), you can add ``--proxy=IP_ADDRESS:PORT`` as an argument on the command line.
 
 ```bash
 pytest proxy_test.py --proxy=IP_ADDRESS:PORT
 ```
 
-If the proxy server that you wish to use requires authentication, you can do the following (Chrome only):
+If the proxy server that you wish to use requires authentication, you can do the following (Chromium only):
 
 ```bash
 pytest proxy_test.py --proxy=USERNAME:PASSWORD@IP_ADDRESS:PORT
+```
+
+SeleniumBase also supports SOCKS4 and SOCKS5 proxies:
+
+```bash
+pytest proxy_test.py --proxy="socks4://IP_ADDRESS:PORT"
+
+pytest proxy_test.py --proxy="socks5://IP_ADDRESS:PORT"
 ```
 
 To make things easier, you can add your frequently-used proxies to PROXY_LIST in [proxy_list.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/proxy_list.py), and then use ``--proxy=KEY_FROM_PROXY_LIST`` to use the IP_ADDRESS:PORT of that key.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ pip install seleniumbase
 
 COMMANDS:
       install         [DRIVER] [OPTIONS]
+      methods         (List common Python methods)
       options         (List common pytest options)
       mkdir           [DIRECTORY] [OPTIONS]
       mkfile          [FILE.py] [OPTIONS]

--- a/examples/offline_examples/test_demo_page.py
+++ b/examples/offline_examples/test_demo_page.py
@@ -97,3 +97,6 @@ class OfflineTestClass(BaseCase):
 
         # Assert exact text
         self.assert_exact_text("Demo Page", "h1")
+
+        # Highlight a page element (also assert visibility)
+        self.highlight("h2")

--- a/examples/test_demo_site.py
+++ b/examples/test_demo_site.py
@@ -94,8 +94,11 @@ class MyTestClass(BaseCase):
         # Assert exact text
         self.assert_exact_text("Demo Page", "h1")
 
+        # Highlight a page element (also assert visibility)
+        self.highlight("h2")
+
         # Assert no broken links (Can be slow if many links)
         # self.assert_no_404_errors()
 
         # Assert no JavaScript errors (Can also detect 404s)
-        self.assert_no_js_errors()
+        # self.assert_no_js_errors()

--- a/help_docs/customizing_test_runs.md
+++ b/help_docs/customizing_test_runs.md
@@ -338,16 +338,24 @@ nosetests test_suite.py --report
 
 <h3><img src="https://seleniumbase.io/img/logo6.png" title="SeleniumBase" width="28" /> Using a Proxy Server:</h3>
 
-If you wish to use a proxy server for your browser tests (Chrome and Firefox only), you can add ``--proxy=IP_ADDRESS:PORT`` as an argument on the command line.
+If you wish to use a proxy server for your browser tests (Chromium or Firefox), you can add ``--proxy=IP_ADDRESS:PORT`` as an argument on the command line.
 
 ```bash
 pytest proxy_test.py --proxy=IP_ADDRESS:PORT
 ```
 
-If the proxy server that you wish to use requires authentication, you can do the following (Chrome only):
+If the proxy server that you wish to use requires authentication, you can do the following (Chromium only):
 
 ```bash
 pytest proxy_test.py --proxy=USERNAME:PASSWORD@IP_ADDRESS:PORT
+```
+
+SeleniumBase also supports SOCKS4 and SOCKS5 proxies:
+
+```bash
+pytest proxy_test.py --proxy="socks4://IP_ADDRESS:PORT"
+
+pytest proxy_test.py --proxy="socks5://IP_ADDRESS:PORT"
 ```
 
 To make things easier, you can add your frequently-used proxies to PROXY_LIST in [proxy_list.py](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/proxy_list.py), and then use ``--proxy=KEY_FROM_PROXY_LIST`` to use the IP_ADDRESS:PORT of that key.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,33 +13,39 @@ docs_dir: "docs"
 copyright: Copyright &copy; 2014 - 2021 Michael Mintz
 # Extensions
 markdown_extensions:
-  - markdown.extensions.admonition
-  - markdown.extensions.attr_list
-  - markdown.extensions.codehilite
-  - markdown.extensions.meta
-  - markdown.extensions.def_list
-  - markdown.extensions.footnotes
-  - markdown.extensions.toc:
+  - admonition
+  - md_in_html
+  - toc:
       permalink: true
+  - pymdownx.highlight:
+      linenums: false
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.details
+  - pymdownx.snippets
 # Configuration
 theme:
   name: material
   logo: img/grad_logo.png
   favicon: img/grad_logo.png
+  language: en
   include_homepage_in_sidebar: true
   sticky_navigation: true
-  language: en
+  # collapse_navigation: false
+  # titles_only: false
   include_search_page: false
   search_index_only: true
   static_templates:
     - 404.html
   features:
-    - navigation.sections
+    # - search.highlight
+    # - toc.integrate
+    - navigation.indexes
+    # - navigation.sections
+    # - navigation.expand
     # - navigation.tabs
     - navigation.instant
-  extra:
-    search:
-      language: en
   palette:
     scheme: default
     primary: blue
@@ -51,10 +57,12 @@ theme:
     logo: img/sb_logo_7.png
 # Plugins
 plugins:
-  - search
+  - search:
+      separator: '[\s\-]+'
+      prebuild_index: true
+      lang: en
   - minify:
       minify_html: true
-      minify_js: true
   - mkdocs-simple-hooks:
       hooks:
         on_pre_build: docs.prepare:main
@@ -99,7 +107,7 @@ nav:
     - Table of Contents: help_docs/ReadMe.md
     - JS Package Manager: help_docs/js_package_manager.md
     - Master QA Hybrid Mode: seleniumbase/masterqa/ReadMe.md
-    - Decorators & Security: seleniumbase/common/ReadMe.md
+    - Decorators / Security: seleniumbase/common/ReadMe.md
     - Desired Capabilities: help_docs/desired_capabilities.md
     - Docker Start Guide: integrations/docker/ReadMe.md
     - Using Safari Driver: help_docs/using_safari_driver.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pip>=21.0.1;python_version>="3.6"
 packaging>=20.9
 setuptools>=44.1.1;python_version<"3.5"
 setuptools>=50.3.2;python_version>="3.5" and python_version<"3.6"
-setuptools>=52.0.0;python_version>="3.6"
+setuptools>=53.0.0;python_version>="3.6"
 setuptools-scm>=5.0.1
 wheel>=0.36.2
 attrs>=20.3.0
@@ -62,11 +62,11 @@ prompt-toolkit==3.0.14;python_version>="3.6"
 ipython==5.10.0;python_version<"3.5"
 ipython==6.5.0;python_version>="3.5" and python_version<"3.6"
 ipython==7.16.1;python_version>="3.6" and python_version<"3.7"
-ipython==7.19.0;python_version>="3.7"
+ipython==7.20.0;python_version>="3.7"
 colorama==0.4.4
 pathlib2==2.3.5;python_version<"3.5"
 importlib-metadata==2.0.0;python_version<"3.6"
-virtualenv>=20.4.1
+virtualenv>=20.4.2
 pymysql==0.10.1;python_version<"3.6"
 pymysql==1.0.2;python_version>="3.6"
 coverage==5.4

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.54.2"
+__version__ = "1.55.0"

--- a/seleniumbase/config/proxy_list.py
+++ b/seleniumbase/config/proxy_list.py
@@ -23,7 +23,7 @@ you can try finding one from one of following sites:
 
 PROXY_LIST = {
     "example1": "152.179.12.86:3128",  # (Example) - set your own proxy here
-    "example2": "176.9.79.126:3128",  # (Example) - set your own proxy here
+    "example2": "socks4://50.197.210.138:32100",  # (Example)
     "proxy1": None,
     "proxy2": None,
     "proxy3": None,

--- a/seleniumbase/console_scripts/ReadMe.md
+++ b/seleniumbase/console_scripts/ReadMe.md
@@ -35,6 +35,14 @@ Installs the specified webdriver.
 (``iedriver`` is required for Internet Explorer automation)
 (``operadriver`` is required for Opera Browser automation)
 
+### methods
+
+* Usage:
+``sbase methods``
+
+* Output:
+Displays common SeleniumBase Python methods.
+
 ### options
 
 * Usage:

--- a/seleniumbase/console_scripts/run.py
+++ b/seleniumbase/console_scripts/run.py
@@ -7,10 +7,11 @@ seleniumbase [COMMAND] [PARAMETERS]
 
 Examples:
 sbase install chromedriver
+sbase methods
+sbase options
 sbase mkdir ui_tests
 sbase mkfile new_test.py
 sbase mkpres new_presentation.py
-sbase options
 sbase convert webdriver_unittest_file.py
 sbase print my_first_test.py -n
 sbase translate my_first_test.py --zh -p
@@ -66,6 +67,7 @@ def show_basic_usage():
     sc += ("\n")
     sc += ("COMMANDS:\n")
     sc += ("      install         [DRIVER] [OPTIONS]\n")
+    sc += ("      methods         (List common Python methods)\n")
     sc += ("      options         (List common pytest options)\n")
     sc += ("      mkdir           [DIRECTORY] [OPTIONS]\n")
     sc += ("      mkfile          [FILE.py] [OPTIONS]\n")
@@ -501,6 +503,62 @@ def show_package_location():
     print("%s" % location)
 
 
+def show_methods():
+    c1 = colorama.Fore.BLUE + colorama.Back.LIGHTCYAN_EX
+    c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
+    c3 = colorama.Fore.BLUE + colorama.Back.LIGHTYELLOW_EX
+    c4 = colorama.Fore.MAGENTA + colorama.Back.LIGHTYELLOW_EX
+    c5 = colorama.Fore.LIGHTRED_EX + colorama.Back.LIGHTGREEN_EX
+    cr = colorama.Style.RESET_ALL
+    sc = ("\n " + c2 + " ** " + c3 + " SeleniumBase Python Methods "
+          "" + c2 + " ** " + cr)
+    print(sc)
+    print("")
+    line = "Here are some common methods that come with SeleniumBase:"
+    line = c1 + line + cr
+    print(line)
+    line = "(Some optional args are not shown here)"
+    print(line)
+    print("")
+    sbm = ""
+    sbm += ('*.open(url) => Navigate the browser window to the URL.\n')
+    sbm += ('*.type(selector, text) => Update the field with the text.\n')
+    sbm += ('*.click(selector) => Click the element with the selector.\n')
+    sbm += ('*.click_link(link_text) => Click the link containing text.\n')
+    sbm += ('*.go_back() => Navigate back to the previous URL.\n')
+    sbm += ('*.select_option_by_text(dropdown_selector, option)\n')
+    sbm += ('*.hover_and_click(hover_selector, click_selector)\n')
+    sbm += ('*.drag_and_drop(drag_selector, drop_selector)\n')
+    sbm += ('*.get_text(selector) => Get the text from the element.\n')
+    sbm += ('*.get_current_url() => Get the URL of the current page.\n')
+    sbm += ('*.get_page_source() => Get the HTML of the current page.\n')
+    sbm += ('*.get_attribute(selector, attribute) => Get element attribute.\n')
+    sbm += ('*.get_title() => Get the title of the current page.\n')
+    sbm += ('*.switch_to_frame(frame) => Switch into the iframe container.\n')
+    sbm += ('*.switch_to_default_content() => Leave the iframe container.\n')
+    sbm += ('*.open_new_window() => Open a new window in the same browser.\n')
+    sbm += ('*.switch_to_window(window) => Switch to the browser window.\n')
+    sbm += ('*.switch_to_default_window() => Switch to the original window.\n')
+    sbm += ('*.get_new_driver(OPTIONS) => Open a new driver with OPTIONS.\n')
+    sbm += ('*.switch_to_driver(driver) => Switch to the browser driver.\n')
+    sbm += ('*.switch_to_default_driver() => Switch to the original driver.\n')
+    sbm += ('*.is_element_visible(selector) => Return True if item visible.\n')
+    sbm += ('*.is_text_visible(text) => Return True if text is visible.\n')
+    sbm += ('*.save_screenshot(name) => Save a screenshot in PNG format.\n')
+    sbm += ('*.assert_element(selector) => Verify the element is visible.\n')
+    sbm += ('*.assert_text(text, selector) => Verify text in the element.\n')
+    sbm += ('*.assert_title(title) => Verify the title of the web page.\n')
+    sbm += ('*.assert_downloaded_file(file) => Verify file was downloaded.\n')
+    sbm += ('*.assert_no_404_errors() => Verify there are no broken links.\n')
+    sbm += ('*.assert_no_js_errors() => Verify there are no JS errors.\n')
+    sbm = sbm.replace("*.", "self." + c1).replace('(', cr + '(')
+    sbm = sbm.replace("self.", c2 + "self" + c5 + "." + cr)
+    sbm = sbm.replace('(', c3 + '(' + c4)
+    sbm = sbm.replace(')', c3 + ')' + cr)
+    print(sbm)
+    print("")
+
+
 def show_options():
     c1 = colorama.Fore.BLUE + colorama.Back.LIGHTCYAN_EX
     c2 = colorama.Fore.BLUE + colorama.Back.LIGHTGREEN_EX
@@ -739,6 +797,8 @@ def main():
             print()
         else:
             show_basic_usage()
+    elif command == "methods" or command == "--methods":
+        show_methods()
     elif command == "options" or command == "--options":
         show_options()
     elif command == "help" or command == "--help":

--- a/seleniumbase/console_scripts/sb_mkdir.py
+++ b/seleniumbase/console_scripts/sb_mkdir.py
@@ -376,6 +376,7 @@ def main():
     data.append('        self.assert_link_text("seleniumbase.io")')
     data.append('        self.click_link("SeleniumBase Demo Page")')
     data.append('        self.assert_exact_text("Demo Page", "h1")')
+    data.append('        self.highlight("h2")')
     data.append("")
     file_path = "%s/%s" % (dir_name, "test_demo_site.py")
     file = codecs.open(file_path, "w+", "utf-8")

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -852,6 +852,19 @@ def get_local_driver(
                 edge_options.add_experimental_option(
                     "mobileEmulation", emulator_settings)
                 edge_options.add_argument("--enable-sync")
+            if user_data_dir:
+                abs_path = os.path.abspath(user_data_dir)
+                edge_options.add_argument("user-data-dir=%s" % abs_path)
+            if extension_zip:
+                # Can be a comma-separated list of .ZIP or .CRX files
+                extension_zip_list = extension_zip.split(',')
+                for extension_zip_item in extension_zip_list:
+                    abs_path = os.path.abspath(extension_zip_item)
+                    edge_options.add_extension(abs_path)
+            if extension_dir:
+                # load-extension input can be a comma-separated list
+                abs_path = os.path.abspath(extension_dir)
+                edge_options.add_argument("--load-extension=%s" % abs_path)
             edge_options.add_argument("--disable-infobars")
             edge_options.add_argument("--disable-save-password-bubble")
             edge_options.add_argument("--disable-single-click-autofill")
@@ -865,7 +878,16 @@ def get_local_driver(
             edge_options.add_argument("--dom-automation")
             edge_options.add_argument("--disable-hang-monitor")
             edge_options.add_argument("--disable-prompt-on-repost")
+            if (settings.DISABLE_CSP_ON_CHROME or disable_csp) and (
+                    not headless):
+                # Headless Edge doesn't support extensions, which are required
+                # for disabling the Content Security Policy on Edge
+                edge_options = _add_chrome_disable_csp_extension(edge_options)
+                edge_options.add_argument("--enable-sync")
             if proxy_string:
+                if proxy_auth:
+                    edge_options = _add_chrome_proxy_extension(
+                        edge_options, proxy_string, proxy_user, proxy_pass)
                 edge_options.add_argument('--proxy-server=%s' % proxy_string)
             edge_options.add_argument("--test-type")
             edge_options.add_argument("--log-level=3")

--- a/seleniumbase/core/log_helper.py
+++ b/seleniumbase/core/log_helper.py
@@ -136,13 +136,43 @@ def log_page_source(test_logpath, driver, source=None):
 
 
 def get_test_id(test):
-    test_id = "%s.%s.%s" % (
-        test.__class__.__module__,
-        test.__class__.__name__,
-        test._testMethodName)
-    if test._sb_test_identifier and len(str(test._sb_test_identifier)) > 6:
-        test_id = test._sb_test_identifier
+    test_id = None
+    try:
+        test_id = get_test_name(test)
+    except Exception:
+        test_id = "%s.%s.%s" % (
+            test.__class__.__module__,
+            test.__class__.__name__,
+            test._testMethodName)
+        if test._sb_test_identifier and len(str(test._sb_test_identifier)) > 6:
+            test_id = test._sb_test_identifier
     return test_id
+
+
+def get_test_name(test):
+    if test.is_pytest:
+        test_name = "%s.py::%s::%s" % (
+            test.__class__.__module__.split('.')[-1],
+            test.__class__.__name__,
+            test._testMethodName)
+    else:
+        test_name = "%s.py:%s.%s" % (
+            test.__class__.__module__.split('.')[-1],
+            test.__class__.__name__,
+            test._testMethodName)
+    if test._sb_test_identifier and len(str(test._sb_test_identifier)) > 6:
+        test_name = test._sb_test_identifier
+        if hasattr(test, "_using_sb_fixture_class"):
+            if test_name.count('.') >= 2:
+                parts = test_name.split('.')
+                full = parts[-3] + '.py::' + parts[-2] + '::' + parts[-1]
+                test_name = full
+        elif hasattr(test, "_using_sb_fixture_no_class"):
+            if test_name.count('.') >= 1:
+                parts = test_name.split('.')
+                full = parts[-2] + '.py::' + parts[-1]
+                test_name = full
+    return test_name
 
 
 def get_last_page(driver):

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -6223,11 +6223,6 @@ class BaseCase(unittest.TestCase):
         element = self.wait_for_element_visible(
             selector, by=by, timeout=settings.SMALL_TIMEOUT)
         try:
-            selector = self.convert_to_css_selector(selector, by=by)
-        except Exception:
-            # Don't highlight if can't convert to CSS_SELECTOR
-            return
-        try:
             scroll_distance = js_utils.get_scroll_distance_to_element(
                 self.driver, element)
             if abs(scroll_distance) > SSMD:
@@ -6240,6 +6235,11 @@ class BaseCase(unittest.TestCase):
             element = self.wait_for_element_visible(
                 selector, by=by, timeout=settings.SMALL_TIMEOUT)
             self.__slow_scroll_to_element(element)
+        try:
+            selector = self.convert_to_css_selector(selector, by=by)
+        except Exception:
+            # Don't highlight if can't convert to CSS_SELECTOR
+            return
 
         o_bs = ''  # original_box_shadow
         try:

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
         'packaging>=20.9',
         'setuptools>=44.1.1;python_version<"3.5"',
         'setuptools>=50.3.2;python_version>="3.5" and python_version<"3.6"',
-        'setuptools>=52.0.0;python_version>="3.6"',
+        'setuptools>=53.0.0;python_version>="3.6"',
         'setuptools-scm>=5.0.1',
         'wheel>=0.36.2',
         'attrs>=20.3.0',
@@ -166,11 +166,11 @@ setup(
         'prompt-toolkit==3.0.14;python_version>="3.6"',
         'ipython==6.5.0;python_version>="3.5" and python_version<"3.6"',
         'ipython==7.16.1;python_version>="3.6" and python_version<"3.7"',
-        'ipython==7.19.0;python_version>="3.7"',
+        'ipython==7.20.0;python_version>="3.7"',
         'colorama==0.4.4',
         'pathlib2==2.3.5;python_version<"3.5"',  # Sync with "virtualenv"
         'importlib-metadata==2.0.0;python_version<"3.6"',  # Sync "virtualenv"
-        'virtualenv>=20.4.1',  # Sync with importlib-metadata and pathlib2
+        'virtualenv>=20.4.2',  # Sync with importlib-metadata and pathlib2
         'pymysql==0.10.1;python_version<"3.6"',
         'pymysql==1.0.2;python_version>="3.6"',
         'coverage==5.4',


### PR DESCRIPTION
### Chrome extensions in Edge, Socks4/5 proxy support, and more
* Add the ability to use Chrome extensions with Microsoft Edge
* Add the ability to set a SOCKS4/5 proxy on the command line
* Fix selector issue with assert_link_text() in Demo Mode
* Update the test name displayed in the ``latest_logs/`` info file
* Add the ``seleniumbase methods`` command to console scripts
* Update Python dependencies:
-- ``setuptools>=53.0.0;python_version>="3.6``
-- ``ipython==7.20.0;python_version>="3.7"``
-- ``virtualenv>=20.4.2``
