### PR TITLE
Allow the choose_file() method to work on hidden "input" fields

### DIFF
--- a/examples/test_swag_labs.py
+++ b/examples/test_swag_labs.py
@@ -48,7 +48,7 @@ class SwagLabsTests(BaseCase):
 
         # Checkout - Add info
         self.click("link=CHECKOUT")
-        self.assert_exact_text("Checkout: Your Information", "div.subheader")
+        self.assert_text("Checkout: Your Information", "div.subheader")
         self.assert_element("a.cart_cancel_link")
         self.type("#first-name", "SeleniumBase")
         self.type("#last-name", "Rocks")
@@ -56,7 +56,7 @@ class SwagLabsTests(BaseCase):
 
         # Checkout - Overview
         self.click("input.btn_primary")
-        self.assert_exact_text("Checkout: Overview", "div.subheader")
+        self.assert_text("Checkout: Overview", "div.subheader")
         self.assert_element("link=CANCEL")
         self.assert_text(item_name, "div.inventory_item_name")
         self.assert_text(item_price, "div.inventory_item_price")

--- a/examples/upload_file_test.py
+++ b/examples/upload_file_test.py
@@ -1,10 +1,10 @@
+""" Testing the self.choose_file() method. """
+
 import os
 from seleniumbase import BaseCase
 
 
 class FileUploadButtonTests(BaseCase):
-
-    """ The main purpose of this is to test the self.choose_file() method. """
 
     def test_file_upload_button(self):
         self.open("https://www.w3schools.com/jsref/tryit.asp"
@@ -15,7 +15,7 @@ class FileUploadButtonTests(BaseCase):
         self.add_css_style(zoom_in)
         self.highlight('input[type="file"]')
         dir_name = os.path.dirname(os.path.abspath(__file__))
-        file_path = dir_name + "/example_logs/screenshot.png"
+        file_path = os.path.join(dir_name, "example_logs/screenshot.png")
         self.choose_file('input[type="file"]', file_path)
         self.demo_mode = True  # Adds highlighting to the assert statement
         self.assert_element('input[type="file"]')

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.56.4"
+__version__ = "1.56.5"


### PR DESCRIPTION
### Allow the ``choose_file()`` method to work on hidden "input" fields
* (The ``choose_file()`` method lets you upload a file to a website using a file-picker.)

#### Example usage:

```python
self.choose_file(selector, file_path)

self.choose_file('input[type="file"]', "my_dir/my_file.txt")
```

See https://github.com/seleniumbase/SeleniumBase/blob/master/examples/upload_file_test.py for an example test that uses this method.
