### PR TITLE
Fix a method that finds unique links

### DIFF
--- a/examples/swag_labs_suite.py
+++ b/examples/swag_labs_suite.py
@@ -5,9 +5,12 @@ from seleniumbase import BaseCase
 
 class SwagLabsTests(BaseCase):
 
-    def login_to_swag_labs(self, username="standard_user"):
+    def login_to_swag_labs(self, username="standard_user", v1=False):
         """ Login to Swag Labs and verify success. """
-        self.open("https://www.saucedemo.com/")
+        url = "https://www.saucedemo.com"
+        if v1:
+            url += "/v1"
+        self.open(url)
         if username not in self.get_text("#login_credentials"):
             self.fail("Invalid user for login: %s" % username)
         self.type("#user-name", username)
@@ -86,12 +89,8 @@ class SwagLabsTests(BaseCase):
     @pytest.mark.run(order=2)
     def test_swag_labs_products_page_links(self, username):
         """ This test checks for 404s on the Swag Labs products page.
-            This test is parameterized on the login user.
-            Swag Labs replaced broken links with dog images for the
-                "problem_user" login, so the test switches those back
-                to demonstrate the "assert_no_404_errors()" method. """
-        self.login_to_swag_labs(username=username)
-        self.set_attributes('img[src*="/sl-404"]', "src", "/bad_link.jpg")
+            This test is parameterized on the login user. """
+        self.login_to_swag_labs(username=username, v1=True)
         self.assert_no_404_errors()
 
     @parameterized.expand([

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ packaging>=20.9
 setuptools>=44.1.1;python_version<"3.5"
 setuptools>=50.3.2;python_version>="3.5" and python_version<"3.6"
 setuptools>=54.0.0;python_version>="3.6"
-setuptools-scm>=5.0.1
+setuptools-scm>=5.0.2
 wheel>=0.36.2
 attrs>=20.3.0
 PyYAML>=5.4.1;python_version>="3.6"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.56.6"
+__version__ = "1.56.7"

--- a/seleniumbase/fixtures/page_utils.py
+++ b/seleniumbase/fixtures/page_utils.py
@@ -166,11 +166,17 @@ def _get_unique_links(page_url, soup):
             elif link.startswith('/'):
                 link = full_base_url + link
             elif link.startswith('./'):
-                link = full_base_url + link[1:]
+                f_b_url = full_base_url
+                if len(simple_url.split('/')) > 1:
+                    f_b_url = full_base_url + "/" + simple_url.split('/')[1]
+                link = f_b_url + link[1:]
             elif link.startswith('#'):
                 link = full_base_url + link
             elif '//' not in link:
-                link = full_base_url + "/" + link
+                f_b_url = full_base_url
+                if len(simple_url.split('/')) > 1:
+                    f_b_url = full_base_url + "/" + simple_url.split('/')[1]
+                link = f_b_url + "/" + link
             else:
                 pass
             unique_links.append(link)

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
         'setuptools>=44.1.1;python_version<"3.5"',
         'setuptools>=50.3.2;python_version>="3.5" and python_version<"3.6"',
         'setuptools>=54.0.0;python_version>="3.6"',
-        'setuptools-scm>=5.0.1',
+        'setuptools-scm>=5.0.2',
         'wheel>=0.36.2',
         'attrs>=20.3.0',
         'PyYAML>=5.4.1;python_version>="3.6"',


### PR DESCRIPTION
### Fix a method that finds unique links
* Fix ``self.get_unique_links()``:
-- (Links where the ``src`` starts with ``./`` weren't being processed correctly.)
-- This also fixes impacted methods such as ``self.assert_no_404_errors()``
* Also update a Python dependency:
-- ``setuptools-scm>=5.0.2``