### PR TITLE
Improve reliability of the HTML-Inspector and JS-loading code

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.59.1"
+__version__ = "1.59.2"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -3324,15 +3324,24 @@ class BaseCase(unittest.TestCase):
             (https://cdnjs.com/libraries/html-inspector)
             Prints the results and also returns them. """
         self.__activate_html_inspector()
+        self.wait_for_ready_state_complete()
         script = ("""HTMLInspector.inspect();""")
-        self.execute_script(script)
+        try:
+            self.execute_script(script)
+        except Exception:
+            # If unable to load the JavaScript, skip inspection and return.
+            msg = "(Unable to load HTML-Inspector JS! Inspection Skipped!)"
+            print("\n" + msg)
+            return(msg)
         time.sleep(0.1)
         browser_logs = []
         try:
             browser_logs = self.driver.get_log('browser')
         except (ValueError, WebDriverException):
             # If unable to get browser logs, skip the assert and return.
-            return("(Unable to Inspect HTML! -> Only works on Chrome!)")
+            msg = "(Unable to Inspect HTML! -> Only works on Chromium!)"
+            print("\n" + msg)
+            return(msg)
         messenger_library = "//cdnjs.cloudflare.com/ajax/libs/messenger"
         url = self.get_current_url()
         header = '\n* HTML Inspection Results: %s' % url

--- a/seleniumbase/fixtures/js_utils.py
+++ b/seleniumbase/fixtures/js_utils.py
@@ -407,11 +407,11 @@ def activate_jquery_confirm(driver):
 
     if not is_jquery_activated(driver):
         add_js_link(driver, jquery_js)
-        wait_for_jquery_active(driver, timeout=0.9)
+        wait_for_jquery_active(driver, timeout=1.2)
     add_css_link(driver, jq_confirm_css)
     add_js_link(driver, jq_confirm_js)
 
-    for x in range(15):
+    for x in range(int(settings.MINI_TIMEOUT * 10.0)):
         # jQuery-Confirm needs a small amount of time to load & activate.
         try:
             driver.execute_script("jconfirm")
@@ -430,14 +430,14 @@ def activate_html_inspector(driver):
         return
     if not is_jquery_activated(driver):
         add_js_link(driver, jquery_js)
+        wait_for_jquery_active(driver, timeout=1.2)
         wait_for_ready_state_complete(driver)
         wait_for_angularjs(driver)
-        wait_for_jquery_active(driver, timeout=1.5)
     add_js_link(driver, html_inspector_js)
     wait_for_ready_state_complete(driver)
     wait_for_angularjs(driver)
 
-    for x in range(15):
+    for x in range(int(settings.MINI_TIMEOUT * 10.0)):
         # HTML-Inspector needs a small amount of time to load & activate.
         try:
             driver.execute_script("HTMLInspector")


### PR DESCRIPTION
### Improve reliability of the HTML-Inspector and JS-loading code

* The HTML-Inspector provides useful information about a web page.
* Example: [examples/test_inspect_html.py](https://github.com/seleniumbase/SeleniumBase/blob/master/examples/test_inspect_html.py) (Chromium browsers only)

```python
from seleniumbase import BaseCase

class HtmlInspectorTests(BaseCase):
    def test_html_inspector(self):
        self.open("https://xkcd.com/1144/")
        self.inspect_html()
```

--------

```bash
pytest test_inspect_html.py 
============================ test session starts ============================
platform darwin -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/michael/github/SeleniumBase/examples, configfile: pytest.ini
plugins: html-2.0.1, rerunfailures-9.1.1, xdist-2.2.1, metadata-1.11.0,
         ordering-0.6, forked-1.3.0, seleniumbase-1.59.2
collected 1 item                                                                                                        

test_inspect_html.py 
* HTML Inspection Results: https://xkcd.com/1144/
X - https://xkcd.com/1144/ - Access to XMLHttpRequest at 'https://xkcd.com/usBanner' (redirected from 'https://c.xkcd.com/xkcd/news') from origin 'https://xkcd.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
X - https://xkcd.com/usBanner - Failed to load resource: net::ERR_FAILED
X - 'property' is not a valid attribute of the <meta> element.
X - Do not use <div> or <span> elements without any attributes.
X - The 'alt' attribute is required for <img> elements.
X - The 'border' attribute is no longer valid on the <img> element and should not be used.
X - 'srcset' is not a valid attribute of the <img> element.
X - The <center> element is obsolete and should not be used.
X - <script> elements should appear right before the closing </body> tag for optimal performance.
X - The id 'comicLinks' appears more than once in the document.
* (See the Console output for details!)
```