### PR TITLE
Add support for migrating from Protractor to SeleniumBase

### DIFF
--- a/examples/migration/protractor/ReadMe.md
+++ b/examples/migration/protractor/ReadMe.md
@@ -1,0 +1,22 @@
+## Support for migrating from Protractor to SeleniumBase
+
+🔵 The Protractor/Angular tests from [github.com/angular/protractor/tree/master/example](https://github.com/angular/protractor/tree/master/example) have been migrated to SeleniumBase and placed in this directory.
+
+✅ Here's a test run with ``pytest`` using ``--reuse-session`` mode and Chromium ``--guest`` mode:
+
+```bash
+$ pytest --rs -v --guest
+# ======================== test session starts ======================== #
+platform darwin -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
+metadata: {'Python': '3.9.2', 'Platform': 'macOS-10.14.6-x86_64-i386-64bit', 'Packages': {'pytest': '6.2.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.0.1', 'rerunfailures': '9.1.1', 'xdist': '2.2.1', 'metadata': '1.11.0', 'ordering': '0.6', 'forked': '1.3.0', 'seleniumbase': '1.59.6'}}
+rootdir: /Users/michael/github/SeleniumBase/examples, configfile: pytest.ini
+plugins: html-2.0.1, rerunfailures-9.1.1, xdist-2.2.1, metadata-1.11.0, ordering-0.6, forked-1.3.0, seleniumbase-1.59.6
+collected 4 items
+
+example_test.py::AngularJSHomePageTests::test_greet_user PASSED
+example_test.py::AngularJSHomePageTests::test_todo_list PASSED
+input_test.py::AngularMaterialInputTests::test_invalid_input PASSED
+mat_paginator_test.py::AngularMaterialPaginatorTests::test_pagination PASSED
+
+# ======================== 4 passed in 10.16s ======================== #
+```

--- a/examples/migration/protractor/example_spec.js
+++ b/examples/migration/protractor/example_spec.js
@@ -1,0 +1,37 @@
+describe('angularjs homepage', function() {
+  it('should greet the named user', function() {
+    browser.get('http://www.angularjs.org');
+
+    element(by.model('yourName')).sendKeys('Julie');
+
+    var greeting = element(by.binding('yourName'));
+
+    expect(greeting.getText()).toEqual('Hello Julie!');
+  });
+
+  describe('todo list', function() {
+    var todoList;
+
+    beforeEach(function() {
+      browser.get('http://www.angularjs.org');
+
+      todoList = element.all(by.repeater('todo in todoList.todos'));
+    });
+
+    it('should list todos', function() {
+      expect(todoList.count()).toEqual(2);
+      expect(todoList.get(1).getText()).toEqual('build an AngularJS app');
+    });
+
+    it('should add a todo', function() {
+      var addTodo = element(by.model('todoList.todoText'));
+      var addButton = element(by.css('[value="add"]'));
+
+      addTodo.sendKeys('write a protractor test');
+      addButton.click();
+
+      expect(todoList.count()).toEqual(3);
+      expect(todoList.get(2).getText()).toEqual('write a protractor test');
+    });
+  });
+});

--- a/examples/migration/protractor/example_test.py
+++ b/examples/migration/protractor/example_test.py
@@ -1,0 +1,23 @@
+from seleniumbase import BaseCase
+
+
+class AngularJSHomePageTests(BaseCase):
+
+    def test_greet_user(self):
+        self.open("http://www.angularjs.org")
+        self.type('[ng-model="yourName"]', "Julie")
+        self.assert_text("Hello Julie!", "h1.ng-binding")
+
+    def test_todo_list(self):
+        self.open("http://www.angularjs.org")
+        todo_selector = '[ng-repeat="todo in todoList.todos"]'
+        # Verify that the todos are listed
+        todos = self.find_visible_elements(todo_selector)
+        self.assert_equal(len(todos), 2)
+        self.assert_equal(todos[1].text, "build an AngularJS app")
+        # Verify adding a new todo
+        self.type('[ng-model="todoList.todoText"]', "write a protractor test")
+        self.click('[value="add"]')
+        todos = self.find_visible_elements(todo_selector)
+        self.assert_equal(len(todos), 3)
+        self.assert_equal(todos[2].text, "write a protractor test")

--- a/examples/migration/protractor/input_spec.js
+++ b/examples/migration/protractor/input_spec.js
@@ -1,0 +1,15 @@
+describe('angular-material input component page', function() {
+  const EC = protractor.ExpectedConditions;
+
+  it('Should change input component value', async() => {
+    await browser.get('https://material.angular.io/components/input/examples');
+      
+    await browser.wait(EC.elementToBeClickable($('.mat-button-wrapper > .mat-icon')), 5000);
+      
+    const emailInputField = $$('#mat-input-1').get(1);
+      
+    await emailInputField.sendKeys('invalid');
+      
+    expect($('mat-error').isPresent()).toBe(true);
+  });
+});

--- a/examples/migration/protractor/input_test.py
+++ b/examples/migration/protractor/input_test.py
@@ -1,0 +1,11 @@
+from seleniumbase import BaseCase
+
+
+class AngularMaterialInputTests(BaseCase):
+
+    def test_invalid_input(self):
+        # Test that there's an error for an invalid input
+        self.open("https://material.angular.io/components/input/examples")
+        self.assert_element(".mat-button-wrapper > .mat-icon")
+        self.type("#mat-input-1", "invalid")
+        self.assert_element("mat-error")

--- a/examples/migration/protractor/mat_paginator_spec.js
+++ b/examples/migration/protractor/mat_paginator_spec.js
@@ -1,0 +1,31 @@
+describe('angular-material paginator component page', () => {
+  const EC = protractor.ExpectedConditions;
+
+  beforeAll(async() => {
+    await browser.get('https://material.angular.io/components/paginator/examples');
+
+    await browser.wait(EC.elementToBeClickable($('.mat-button-wrapper > .mat-icon')), 5000);
+  });
+
+  it('Should navigate to next page', async() => {
+    await $('button[aria-label=\'Next page\']').click();
+    
+    await expect($('.mat-paginator-range-label').getAttribute('innerText')).toEqual('11 – 20 of 100');
+  });
+
+  it('Should navigate to previous page', async() => {
+    await $('button[aria-label=\'Previous page\']').click();
+    
+    await expect($('.mat-paginator-range-label').getAttribute('innerText')).toEqual('1 – 10 of 100');
+  });
+
+  it('Should change list length to 5 items per page', async() => {
+    await $('mat-select > div').click();
+    
+    const fiveItemsOption = $$('mat-option > .mat-option-text').first();
+
+    await fiveItemsOption.click();
+    
+    await expect($('.mat-paginator-range-label').getAttribute('innerText')).toEqual('1 – 5 of 100');
+  });
+});

--- a/examples/migration/protractor/mat_paginator_test.py
+++ b/examples/migration/protractor/mat_paginator_test.py
@@ -1,0 +1,18 @@
+from seleniumbase import BaseCase
+
+
+class AngularMaterialPaginatorTests(BaseCase):
+
+    def test_pagination(self):
+        self.open("https://material.angular.io/components/paginator/examples")
+        self.assert_element(".mat-button-wrapper > .mat-icon")
+        # Verify navigation to the next page
+        self.click('button[aria-label="Next page"]')
+        self.assert_text("11 – 20 of 100", ".mat-paginator-range-label")
+        # Verify navigation to the previous page
+        self.click('button[aria-label="Previous page"]')
+        self.assert_text("1 – 10 of 100", ".mat-paginator-range-label")
+        # Verify changed list length to 5 items per page
+        self.click("mat-select > div")
+        self.click("mat-option > .mat-option-text")
+        self.assert_text("1 – 5 of 100", ".mat-paginator-range-label")


### PR DESCRIPTION
### Add support for migrating from Protractor to SeleniumBase

🔵 The Protractor/Angular tests from [github.com/angular/protractor/tree/master/example](https://github.com/angular/protractor/tree/master/example) have been migrated to SeleniumBase.

✅ Here's a test run with ``pytest`` using ``--reuse-session`` mode and Chromium ``--guest`` mode:

```bash
$ pytest --rs -v --guest
# ======================== test session starts ======================== #
platform darwin -- Python 3.9.2, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
metadata: {'Python': '3.9.2', 'Platform': 'macOS-10.14.6-x86_64-i386-64bit', 'Packages': {'pytest': '6.2.3', 'py': '1.10.0', 'pluggy': '0.13.1'}, 'Plugins': {'html': '2.0.1', 'rerunfailures': '9.1.1', 'xdist': '2.2.1', 'metadata': '1.11.0', 'ordering': '0.6', 'forked': '1.3.0', 'seleniumbase': '1.59.6'}}
rootdir: /Users/michael/github/SeleniumBase/examples, configfile: pytest.ini
plugins: html-2.0.1, rerunfailures-9.1.1, xdist-2.2.1, metadata-1.11.0, ordering-0.6, forked-1.3.0, seleniumbase-1.59.6
collected 4 items
example_test.py::AngularJSHomePageTests::test_greet_user PASSED
example_test.py::AngularJSHomePageTests::test_todo_list PASSED
input_test.py::AngularMaterialInputTests::test_invalid_input PASSED
mat_paginator_test.py::AngularMaterialPaginatorTests::test_pagination PASSED
# ======================== 4 passed in 10.16s ======================== #
```
