### PR TITLE
Compatibility updates and more

### DIFF
--- a/examples/migration/protractor/mat_paginator_test.py
+++ b/examples/migration/protractor/mat_paginator_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from seleniumbase import BaseCase
 
 

--- a/examples/pytest.ini
+++ b/examples/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 
-# Display console output and disable the cacheprovider.
-addopts = --capture=no -p no:cacheprovider
+# Display console output, disable cacheprovider, and have the ipdb debugger replace pdb:
+addopts = --capture=no -p no:cacheprovider --pdbcls=IPython.terminal.debugger:TerminalPdb
 
 # Ignore warnings such as DeprecationWarning and PytestUnknownMarkWarning
 filterwarnings =

--- a/examples/translations/pytest.ini
+++ b/examples/translations/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 
-# Display console output and disable the cacheprovider.
-addopts = --capture=no -p no:cacheprovider
+# Display console output, disable cacheprovider, and have the ipdb debugger replace pdb:
+addopts = --capture=no -p no:cacheprovider --pdbcls=IPython.terminal.debugger:TerminalPdb
 
 # Ignore warnings such as DeprecationWarning and PytestUnknownMarkWarning
 filterwarnings =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 
-# Display console output and disable the cacheprovider.
-addopts = --capture=no -p no:cacheprovider
+# Display console output, disable cacheprovider, and have the ipdb debugger replace pdb:
+addopts = --capture=no -p no:cacheprovider --pdbcls=IPython.terminal.debugger:TerminalPdb
 
 # Ignore warnings such as DeprecationWarning and PytestUnknownMarkWarning
 filterwarnings =

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ packaging>=20.9
 typing-extensions>=3.10.0.0
 setuptools>=44.1.1;python_version<"3.5"
 setuptools>=50.3.2;python_version>="3.5" and python_version<"3.6"
-setuptools>=56.1.0;python_version>="3.6"
+setuptools>=56.2.0;python_version>="3.6"
 setuptools-scm==5.0.2;python_version<"3.6"
 setuptools-scm>=6.0.1;python_version>="3.6"
 wheel>=0.36.2
@@ -63,7 +63,8 @@ traitlets==4.3.3;python_version<"3.7"
 traitlets==5.0.5;python_version>="3.7"
 prompt-toolkit==1.0.18;python_version<"3.6"
 prompt-toolkit==3.0.18;python_version>="3.6"
-decorator==4.4.2
+decorator==4.4.2;python_version<"3.5"
+decorator==5.0.7;python_version>="3.5"
 ipython==5.10.0;python_version<"3.5"
 ipython==6.5.0;python_version>="3.5" and python_version<"3.6"
 ipython==7.16.1;python_version>="3.6" and python_version<"3.7"
@@ -94,7 +95,7 @@ pdfminer.six==20201018;python_version>="3.5"
 coverage==5.5
 pytest-cov==2.11.1
 flake8==3.7.9;python_version<"3.5"
-flake8==3.9.1;python_version>="3.5"
+flake8==3.9.2;python_version>="3.5"
 pyflakes==2.1.1;python_version<"3.5"
 pyflakes==2.3.1;python_version>="3.5"
 pycodestyle==2.5.0;python_version<"3.5"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.63.3"
+__version__ = "1.63.4"

--- a/seleniumbase/console_scripts/sb_mkdir.py
+++ b/seleniumbase/console_scripts/sb_mkdir.py
@@ -123,7 +123,10 @@ def main():
 
     data = []
     data.append("[pytest]")
-    data.append("addopts = --capture=no -p no:cacheprovider")
+    data.append(
+        "addopts = --capture=no -p no:cacheprovider "
+        "--pdbcls=IPython.terminal.debugger:TerminalPdb"
+    )
     data.append("filterwarnings =")
     data.append("    ignore::pytest.PytestWarning")
     data.append("    ignore:.*U.*mode is deprecated:DeprecationWarning")

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -57,6 +57,9 @@ logging.getLogger("requests").setLevel(logging.ERROR)
 logging.getLogger("urllib3").setLevel(logging.ERROR)
 urllib3.disable_warnings()
 LOGGER.setLevel(logging.WARNING)
+if sys.version_info[0] < 3:
+    reload(sys)  # noqa: F821
+    sys.setdefaultencoding("utf8")
 
 
 class BaseCase(unittest.TestCase):
@@ -3248,14 +3251,14 @@ class BaseCase(unittest.TestCase):
 
     def __fix_unicode_conversion(self, text):
         """ Fixing Chinese characters when converting from PDF to HTML. """
-        if sys.version_info[0] < 3:
-            # Update encoding for Python 2 users
-            reload(sys)  # noqa
-            sys.setdefaultencoding("utf8")
         text = text.replace("\u2f8f", "\u884c")
         text = text.replace("\u2f45", "\u65b9")
         text = text.replace("\u2f08", "\u4eba")
         text = text.replace("\u2f70", "\u793a")
+        text = text.replace("\xe2\xbe\x8f", "\xe8\xa1\x8c")
+        text = text.replace("\xe2\xbd\xb0", "\xe7\xa4\xba")
+        text = text.replace("\xe2\xbe\x8f", "\xe8\xa1\x8c")
+        text = text.replace("\xe2\xbd\x85", "\xe6\x96\xb9")
         return text
 
     def get_pdf_text(
@@ -8114,7 +8117,7 @@ class BaseCase(unittest.TestCase):
         _type = type(selector)  # First make sure the selector is a string
         not_string = False
         if sys.version_info[0] < 3:
-            if _type is not str and _type is not unicode:  # noqa
+            if _type is not str and _type is not unicode:  # noqa: F821
                 not_string = True
         else:
             if _type is not str:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ The setup package to install SeleniumBase dependencies and plugins
 (Uses selenium 3.x and is compatible with Python 2.7+ and Python 3.5+)
 """
 
-from setuptools import setup, find_packages  # noqa
+from setuptools import setup, find_packages  # noqa: F401
 import os
 import sys
 
@@ -31,12 +31,12 @@ if sys.argv[-1] == "publish":
     reply = None
     input_method = input
     if not sys.version_info[0] >= 3:
-        input_method = raw_input  # noqa
+        input_method = raw_input  # noqa: F821
     confirm_text = ">>> Confirm release PUBLISH to PyPI? (yes/no): "
     reply = str(input_method(confirm_text)).lower().strip()
     if reply == "yes":
         print("\n*** Checking code health with flake8:\n")
-        os.system("python -m pip install 'flake8==3.9.1'")
+        os.system("python -m pip install 'flake8==3.9.2'")
         flake8_status = os.system("flake8 --exclude=temp")
         if flake8_status != 0:
             print("\nWARNING! Fix flake8 issues before publishing to PyPI!\n")
@@ -119,7 +119,7 @@ setup(
         "typing-extensions>=3.10.0.0",
         'setuptools>=44.1.1;python_version<"3.5"',
         'setuptools>=50.3.2;python_version>="3.5" and python_version<"3.6"',
-        'setuptools>=56.1.0;python_version>="3.6"',
+        'setuptools>=56.2.0;python_version>="3.6"',
         'setuptools-scm==5.0.2;python_version<"3.6"',
         'setuptools-scm>=6.0.1;python_version>="3.6"',
         "wheel>=0.36.2",
@@ -178,7 +178,8 @@ setup(
         'traitlets==5.0.5;python_version>="3.7"',
         'prompt-toolkit==1.0.18;python_version<"3.6"',
         'prompt-toolkit==3.0.18;python_version>="3.6"',
-        "decorator==4.4.2",
+        'decorator==4.4.2;python_version<"3.5"',
+        'decorator==5.0.7;python_version>="3.5"',
         'ipython==5.10.0;python_version<"3.5"',
         'ipython==6.5.0;python_version>="3.5" and python_version<"3.6"',
         'ipython==7.16.1;python_version>="3.6" and python_version<"3.7"',
@@ -212,7 +213,7 @@ setup(
         # pip install -e .[flake]
         "flake": [
             'flake8==3.7.9;python_version<"3.5"',
-            'flake8==3.9.1;python_version>="3.5"',
+            'flake8==3.9.2;python_version>="3.5"',
             'pyflakes==2.1.1;python_version<"3.5"',
             'pyflakes==2.3.1;python_version>="3.5"',
             'pycodestyle==2.5.0;python_version<"3.5"',


### PR DESCRIPTION
### Compatibility updates and more
* Improve compatibility on older versions of Python.
* Use the IPython debugger by default (``ipdb``).
* Update Python dependencies:
-- ``setuptools>=56.2.0;python_version>="3.6"``
-- ``decorator==5.0.7;python_version>="3.5"``