### PR TITLE
Update visual baseline folder naming and dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,8 @@ livereload==2.6.3;python_version>="3.6"
 joblib==1.0.1;python_version>="3.6"
 Markdown==3.3.4
 docutils==0.17.1
-Jinja2==2.11.3
+Jinja2==3.0.0;python_version>="3.6"
+click==8.0.0
 readme-renderer==29.0
 pymdown-extensions==8.2
 importlib-metadata==4.0.1;python_version>="3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,7 +83,7 @@ toml==0.10.2
 Pillow==6.2.2;python_version<"3.5"
 Pillow==7.2.0;python_version>="3.5" and python_version<"3.6"
 Pillow==8.2.0;python_version>="3.6"
-rich==10.1.0;python_version>="3.6" and python_version<"4.0"
+rich==10.2.0;python_version>="3.6" and python_version<"4.0"
 tornado==5.1.1;python_version<"3.5"
 tornado==6.1;python_version>="3.5"
 pdfminer.six==20191110;python_version<"3.5"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.63.4"
+__version__ = "1.63.5"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -7582,10 +7582,8 @@ class BaseCase(unittest.TestCase):
             )
             logging.info(message)
 
-        module = self.__class__.__module__
-        if "." in module and len(module.split(".")[-1]) > 1:
-            module = module.split(".")[-1]
-        test_id = "%s.%s" % (module, self._testMethodName)
+        test_id = self.__get_display_id().split("::")[-1]
+
         if not name or len(name) < 1:
             name = "default"
         name = str(name)

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ setup(
         'Pillow==6.2.2;python_version<"3.5"',
         'Pillow==7.2.0;python_version>="3.5" and python_version<"3.6"',
         'Pillow==8.2.0;python_version>="3.6"',
-        'rich==10.1.0;python_version>="3.6" and python_version<"4.0"',
+        'rich==10.2.0;python_version>="3.6" and python_version<"4.0"',
         'tornado==5.1.1;python_version<"3.5"',
         'tornado==6.1;python_version>="3.5"',
         'pdfminer.six==20191110;python_version<"3.5"',


### PR DESCRIPTION
### Update visual baseline folder naming and dependencies
* Fix https://github.com/seleniumbase/SeleniumBase/issues/903 by making the visual layout comparison be done against ``test/name`` instead of ``file_class_test/name``. This lets two different tests (same name, but located in different files/classes) be able to do a visual layout comparison against each other.
* Also update Python dependencies: (``rich==10.2.0;python_version>="3.6"``)