### PR TITLE
Update cryptography to 3.4.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ soupsieve==2.2.1;python_version>="3.6"
 beautifulsoup4==4.9.3
 cryptography==2.9.2;python_version<"3.5"
 cryptography==3.0;python_version>="3.5" and python_version<"3.6"
-cryptography==3.3.2;python_version>="3.6"
+cryptography==3.4.7;python_version>="3.6"
 pyopenssl==19.1.0;python_version<"3.6"
 pyopenssl==20.0.1;python_version>="3.6"
 pygments==2.5.2;python_version<"3.5"

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ setup(
         "beautifulsoup4==4.9.3",
         'cryptography==2.9.2;python_version<"3.5"',
         'cryptography==3.0;python_version>="3.5" and python_version<"3.6"',
-        'cryptography==3.3.2;python_version>="3.6"',
+        'cryptography==3.4.7;python_version>="3.6"',
         'pyopenssl==19.1.0;python_version<"3.6"',
         'pyopenssl==20.0.1;python_version>="3.6"',
         'pygments==2.5.2;python_version<"3.5"',


### PR DESCRIPTION
Upstream changelog [here](https://cryptography.io/en/latest/changelog/#v3-4)

Closes #920 