### PR TITLE
Fix issue with the ":contains()" selector and Demo Mode

### DIFF
--- a/examples/test_contains_selector.py
+++ b/examples/test_contains_selector.py
@@ -4,6 +4,6 @@ from seleniumbase import BaseCase
 class ContainsSelectorTests(BaseCase):
     def test_contains_selector(self):
         self.open("https://xkcd.com/2207/")
-        self.assert_text("Math Work", "#ctitle")
+        self.assert_element('div.box div:contains("Math Work")')
         self.click('a:contains("Next")')
-        self.assert_text("Drone Fishing", "#ctitle")
+        self.assert_element('div div:contains("Drone Fishing")')

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.63.18"
+__version__ = "1.63.19"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -6984,7 +6984,9 @@ class BaseCase(unittest.TestCase):
             return True
         self.wait_for_element_visible(selector, by=by, timeout=timeout)
         if self.demo_mode:
-            selector, by = self.__recalculate_selector(selector, by)
+            selector, by = self.__recalculate_selector(
+                selector, by, xp_ok=False
+            )
             a_t = "ASSERT"
             if self._language != "English":
                 from seleniumbase.fixtures.words import SD
@@ -8279,7 +8281,7 @@ class BaseCase(unittest.TestCase):
     def __highlight_with_assert_success(
         self, message, selector, by=By.CSS_SELECTOR
     ):
-        selector, by = self.__recalculate_selector(selector, by)
+        selector, by = self.__recalculate_selector(selector, by, xp_ok=False)
         element = self.wait_for_element_visible(
             selector, by=by, timeout=settings.SMALL_TIMEOUT
         )


### PR DESCRIPTION
### Fix issue with the ``:contains()`` selector and Demo Mode
* Fix issue causing Demo Mode highlighting to not work when using a multi-syllable ``:contains()`` selector.
