### PR TITLE
Dialog Boxes and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ nosetests [FILE_NAME.py]:[CLASS_NAME].[METHOD_NAME]
 <img src="https://img.shields.io/badge/Flaky Tests%3F-%20NO%21-11BBDD.svg" alt="NO MORE FLAKY TESTS!" />
 
 ✅ Automated/Manual Hybrid Mode:
-<p>SeleniumBase includes a solution called <b><a href="https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/masterqa/ReadMe.md">MasterQA</a></b>, which speeds up manual testing by having automation perform all the browser actions while the manual tester handles validation.</p>
+<p>SeleniumBase includes a solution called <b><a href="https://github.com/seleniumbase/SeleniumBase/blob/master/examples/master_qa/ReadMe.md">MasterQA</a></b>, which speeds up manual testing by having automation perform all the browser actions while the manual tester handles validation.</p>
 
 ✅ Feature-Rich:
 <p>For a full list of SeleniumBase features, <a href="https://github.com/seleniumbase/SeleniumBase/blob/master/help_docs/features_list.md">Click Here</a>.</p>

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@
 <a href="https://github.com/seleniumbase/SeleniumBase/blob/master/examples/tour_examples/ReadMe.md">🗺️ Tours</a> |
 <a href="https://github.com/seleniumbase/SeleniumBase/blob/master/examples/chart_maker/ReadMe.md">📶 Charts</a> |
 <a href="https://github.com/seleniumbase/SeleniumBase/blob/master/examples/presenter/ReadMe.md">📰 Present</a> |
-<a href="https://github.com/seleniumbase/SeleniumBase/blob/master/examples/visual_testing/ReadMe.md">🖼️ VisualTest</a> |
-<a href="https://github.com/seleniumbase/SeleniumBase/blob/master/examples/master_qa/ReadMe.md">🛂 MasterQA</a>
+<a href="https://github.com/seleniumbase/SeleniumBase/blob/master/examples/dialog_boxes/ReadMe.md">🛂 DialogBox</a> |
+<a href="https://github.com/seleniumbase/SeleniumBase/blob/master/examples/visual_testing/ReadMe.md">🖼️ VisualTest</a>
 </p>
 
 <p align="left">

--- a/examples/dialog_boxes/ReadMe.md
+++ b/examples/dialog_boxes/ReadMe.md
@@ -1,0 +1,180 @@
+<h3 align="left"><img src="https://seleniumbase.io/cdn/img/sb_logo_b.png" alt="SeleniumBase" width="320" /></h3>
+
+<h2><img src="https://seleniumbase.io/img/logo6.png" title="SeleniumBase" width="32" /> 🛂 Dialog Boxes 🛂</h2>
+
+SeleniumBase Dialog Boxes let your users provide input in the middle of automation scripts.
+
+* This feature utilizes the [jquery-confirm](https://craftpip.github.io/jquery-confirm/) library.
+* A Python API is used to call the JavaScript API.
+
+<img src="https://seleniumbase.io/cdn/img/emoji_sports_dialog.png" alt="SeleniumBase" width="440" />
+
+<h4>↕️ (<a href="https://github.com/seleniumbase/SeleniumBase/blob/master/examples/dialog_boxes/dialog_box_tour.py">Example: dialog_box_tour.py</a>) ↕️</h4>
+
+<img src="https://seleniumbase.io/cdn/gif/sports_dialog.gif" alt="SeleniumBase" width="440" />
+
+<h4>Here's how to run that example:</h4>
+
+```bash
+cd examples/dialog_boxes
+pytest test_dialog_boxes.py
+```
+
+<h4>Here's a code snippet from that:</h4>
+
+```python
+self.open("https://xkcd.com/1920/")
+skip_button = ["SKIP", "red"]  # Can be a [text, color] list or tuple.
+buttons = ["Fencing", "Football", "Metaball", "Go/Chess", skip_button]
+message = "Choose a sport:"
+choice = self.get_jqc_button_input(message, buttons)
+if choice == "Fencing":
+    self.open("https://xkcd.com/1424/")
+```
+
+* You can create forms that include buttons and input fields.
+
+<h4>Here's a simple form with only buttons as input:</h4>
+
+```python
+choice = self.get_jqc_button_input("Ready?", ["YES", "NO"])
+print(choice)  # This prints "YES" or "NO"
+
+# You may want to customize the color of buttons:
+buttons = [("YES", "green"), ("NO", "red")]
+choice = self.get_jqc_button_input("Ready?", buttons)
+```
+
+<h4>Here's a simple form with an input field:</h4>
+
+```python
+text = self.get_jqc_text_input("Enter text:", ["Search"])
+print(text)  # This prints the text entered
+```
+
+<h4>This form has an input field and buttons:</h4>
+
+```python
+message = "Type your name and choose a language:"
+buttons = ["Python", "JavaScript"]
+text, choice = self.get_jqc_form_inputs(message, buttons)
+print("Your name is: %s" % text)
+print("You picked %s!" % choice)
+```
+
+<h4>You can customize options if you want:</h4>
+
+```python
+# Themes: bootstrap, modern, material, supervan, light, dark, seamless
+options = [("theme", "modern"), ("width", "50%")]
+self.get_jqc_text_input("You Won!", ["OK"], options)
+```
+
+<h4>Default options can be set with <code>set_jqc_theme()</code>:</h4>
+
+```python
+self.set_jqc_theme("light", color="green", width="38%")
+
+# To reset jqc theme settings to factory defaults:
+self.reset_jqc_theme()
+```
+
+<h3>All methods for Dialog Boxes:</h3>
+
+```python
+self.get_jqc_button_input(message, buttons, options=None)
+
+self.get_jqc_text_input(message, button=None, options=None)
+
+self.get_jqc_form_inputs(message, buttons, options=None)
+
+self.set_jqc_theme(theme, color=None, width=None)
+
+self.reset_jqc_theme()
+
+self.activate_jquery_confirm()  # Automatic for jqc methods
+```
+
+<h3>Detailed method summaries for Dialog Boxes:</h3>
+
+```python
+self.get_jqc_button_input(message, buttons, options=None)
+"""
+Pop up a jquery-confirm box and return the text of the button clicked.
+If running in headless mode, the last button text is returned.
+@Params
+message: The message to display in the jquery-confirm dialog.
+buttons: A list of tuples for text and color.
+    Example: [("Yes!", "green"), ("No!", "red")]
+    Available colors: blue, green, red, orange, purple, default, dark.
+    A simple text string also works: "My Button". (Uses default color.)
+options: A list of tuples for options to set.
+    Example: [("theme", "bootstrap"), ("width", "450px")]
+    Available theme options: bootstrap, modern, material, supervan,
+                             light, dark, and seamless.
+    Available colors: (For the BORDER color, NOT the button color.)
+        "blue", "default", "green", "red", "purple", "orange", "dark".
+    Example option for changing the border color: ("color", "default")
+    Width can be set using percent or pixels. Eg: "36.0%", "450px".
+"""
+
+self.get_jqc_text_input(message, button=None, options=None)
+"""
+Pop up a jquery-confirm box and return the text submitted by the input.
+If running in headless mode, the text returned is "" by default.
+@Params
+message: The message to display in the jquery-confirm dialog.
+button: A 2-item list or tuple for text and color. Or just the text.
+    Example: ["Submit", "blue"] -> (default button if not specified)
+    Available colors: blue, green, red, orange, purple, default, dark.
+    A simple text string also works: "My Button". (Uses default color.)
+options: A list of tuples for options to set.
+    Example: [("theme", "bootstrap"), ("width", "450px")]
+    Available theme options: bootstrap, modern, material, supervan,
+                             light, dark, and seamless.
+    Available colors: (For the BORDER color, NOT the button color.)
+        "blue", "default", "green", "red", "purple", "orange", "dark".
+    Example option for changing the border color: ("color", "default")
+    Width can be set using percent or pixels. Eg: "36.0%", "450px".
+"""
+
+self.get_jqc_form_inputs(message, buttons, options=None)
+"""
+Pop up a jquery-confirm box and return the input/button texts as tuple.
+If running in headless mode, returns the ("", buttons[-1][0]) tuple.
+@Params
+message: The message to display in the jquery-confirm dialog.
+buttons: A list of tuples for text and color.
+    Example: [("Yes!", "green"), ("No!", "red")]
+    Available colors: blue, green, red, orange, purple, default, dark.
+    A simple text string also works: "My Button". (Uses default color.)
+options: A list of tuples for options to set.
+    Example: [("theme", "bootstrap"), ("width", "450px")]
+    Available theme options: bootstrap, modern, material, supervan,
+                             light, dark, and seamless.
+    Available colors: (For the BORDER color, NOT the button color.)
+        "blue", "default", "green", "red", "purple", "orange", "dark".
+    Example option for changing the border color: ("color", "default")
+    Width can be set using percent or pixels. Eg: "36.0%", "450px".
+"""
+
+self.set_jqc_theme(theme, color=None, width=None)
+""" Sets the default jquery-confirm theme and width (optional).
+Available themes: "bootstrap", "modern", "material", "supervan",
+                  "light", "dark", and "seamless".
+Available colors: (This sets the BORDER color, NOT the button color.)
+    "blue", "default", "green", "red", "purple", "orange", "dark".
+Width can be set using percent or pixels. Eg: "36.0%", "450px".
+"""
+
+self.reset_jqc_theme()
+""" Resets the jqc theme settings to factory defaults. """
+
+self.activate_jquery_confirm()  # Automatic for jqc methods
+""" See https://craftpip.github.io/jquery-confirm/ for usage. """
+```
+
+--------
+
+<h4>✅ 🛂 Automated/Manual Hybrid Mode (MasterQA)</h4>
+<p><b><a href="https://seleniumbase.io/seleniumbase/masterqa/ReadMe/">MasterQA</a></b> uses <b>SeleniumBase Dialog Boxes</b> to speed up manual testing by having automation perform all the browser actions while the manual tester handles validation. See <a href="https://github.com/seleniumbase/SeleniumBase/tree/master/examples/master_qa">the MasterQA GitHub page</a> for examples.</p>

--- a/examples/dialog_boxes/dialog_box_tour.py
+++ b/examples/dialog_boxes/dialog_box_tour.py
@@ -1,0 +1,117 @@
+from seleniumbase import BaseCase
+
+
+class DialogBoxTests(BaseCase):
+    def test_dialog_boxes(self):
+        self.open("https://xkcd.com/1920/")
+        self.assert_element('img[alt="Emoji Sports"]')
+        self.highlight("#comic img")
+
+        skip_button = ["SKIP", "red"]  # Can be a [text, color] list or tuple.
+        buttons = ["Fencing", "Football", "Metaball", "Go/Chess", skip_button]
+        message = "Choose a sport:"
+        choice = None
+        while choice != "STOP":
+            choice = self.get_jqc_button_input(message, buttons)
+            if choice == "Fencing":
+                self.open("https://xkcd.com/1424/")
+                buttons.remove("Fencing")
+            elif choice == "Football":
+                self.open("https://xkcd.com/1107/")
+                buttons.remove("Football")
+            elif choice == "Metaball":
+                self.open("https://xkcd.com/1507/")
+                buttons.remove("Metaball")
+            elif choice == "Go/Chess":
+                self.open("https://xkcd.com/1287/")
+                buttons.remove("Go/Chess")
+            else:
+                break
+            self.highlight("#comic img")
+            if len(buttons) == 2:
+                message = "One Sport Remaining:"
+            if len(buttons) == 1:
+                message = "Part One Complete. You saw all 4 sports!"
+                btn_text_1 = "NEXT Tutorial Please!"
+                btn_text_2 = "WAIT, Go/Chess is a sport?"
+                buttons = [(btn_text_1, "green"), (btn_text_2, "purple")]
+                choice_2 = self.get_jqc_button_input(message, buttons)
+                if choice_2 == btn_text_2:
+                    self.open("https://xkcd.com/1287/")
+                    message = "Brain sports count as sports!<br /><br />"
+                    message += "Are you ready for more?"
+                    self.get_jqc_button_input(message, ["Let's Go!"])
+                break
+
+        self.open("https://xkcd.com/1117/")
+        sb_banner_logo = "//seleniumbase.io/cdn/img/sb_logo_cs.png"
+        self.set_attributes("#news img", "src", sb_banner_logo)
+        options = [("theme", "material"), ("width", "52%")]
+        message = 'With one button, you can press "Enter/Return", "Y", or "1".'
+        self.get_jqc_button_input(message, ["OK"], options)
+
+        self.open("https://xkcd.com/556/")
+        self.set_attributes("#news img", "src", sb_banner_logo)
+        options = [("theme", "bootstrap"), ("width", "52%")]
+        message = 'If the lowercase button text is "yes" or "no", '
+        message += '<br><br>you can use the "Y" or "N" keys as shortcuts. '
+        message += '<br><br><br>Other shortcuts include: <br><br>'
+        message += '"1": 1st button, "2": 2nd button, etc. Got it?'
+        buttons = [("YES", "green"), ("NO", "red")]
+        choice = self.get_jqc_button_input(message, buttons, options)
+
+        message = 'You said "%s"! <br><br>' % choice
+        if choice == "YES":
+            message += "Wonderful! Let's continue with the next example..."
+        else:
+            message += "You can learn more from SeleniumBase Docs..."
+        choice = self.get_jqc_button_input(message, ["OK"], options)
+
+        self.open("https://seleniumbase.io")
+        self.set_jqc_theme("light", color="green", width="38%")
+        message = "<b>This is the SeleniumBase Docs website!</b><br /><br />"
+        message += "What would you like to search for?<br />"
+        text = self.get_jqc_text_input(message, ["Search"])
+        self.update_text('input[aria-label="Search"]', text + "\n")
+        self.wait_for_ready_state_complete()
+        self.set_jqc_theme("bootstrap", color="red", width="32%")
+        if self.is_text_visible("No matching documents", ".md-search-result"):
+            self.get_jqc_button_input("Your search had no results!", ["OK"])
+        elif self.is_element_visible("a.md-search-result__link"):
+            self.click("a.md-search-result__link")
+            self.set_jqc_theme("bootstrap", color="green", width="32%")
+            self.get_jqc_button_input("You found search results!", ["OK"])
+        elif self.is_text_visible("Type to start searching", "div.md-search"):
+            self.get_jqc_button_input("You did not do a search!", ["OK"])
+        else:
+            self.get_jqc_button_input("We're not sure what happened.", ["OK"])
+
+        self.open("https://seleniumbase.io/help_docs/ReadMe/")
+        self.highlight("h1")
+        self.highlight_click('a:contains("Running Example Tests")')
+        self.highlight("h1")
+
+        self.set_jqc_theme("bootstrap", color="green", width="52%")
+        message = 'See the "SeleniumBase/examples" section for more info!'
+        self.get_jqc_button_input(message, ["OK"])
+
+        self.set_jqc_theme("bootstrap", color="purple", width="56%")
+        message = "Now let's combine form inputs with multiple button options!"
+        message += "<br /><br />"
+        message += "Pick something to search. Then pick the site to search on."
+        buttons = ["XKCD.com", "Wikipedia.org"]
+        text, choice = self.get_jqc_form_inputs(message, buttons)
+        if choice == "XKCD.com":
+            self.open("https://relevant-xkcd.github.io/")
+        else:
+            self.open("https://en.wikipedia.org/wiki/Main_Page")
+        self.highlight_update_text('input[name="search"]', text + "\n")
+        self.wait_for_ready_state_complete()
+        self.highlight("body")
+        self.reset_jqc_theme()
+        self.get_jqc_button_input("<b>Here are your results.</b>", ["OK"])
+        message = "<h3>You've reached the end of this tutorial!</h3><br />"
+        message += "Thanks for learning about SeleniumBase Dialog Boxes!<br />"
+        message += "<br />Check out the SeleniumBase page on GitHub for more!"
+        self.set_jqc_theme("modern", color="purple", width="56%")
+        self.get_jqc_button_input(message, ["Goodbye!"])

--- a/help_docs/ReadMe.md
+++ b/help_docs/ReadMe.md
@@ -5,35 +5,35 @@
 <p align="left">
 <a href="https://seleniumbase.io/#python_installation">🚀 Start</a> |
 <a href="https://seleniumbase.io/help_docs/customizing_test_runs/">🖥️ CLI</a> |
-<a href="https://seleniumbase.io/help_docs/features_list/">🗂️ Features</a>
+<a href="https://seleniumbase.io/help_docs/features_list/">🏰 Features</a>
 <br />
-<a href="https://seleniumbase.io/examples/ReadMe/">📖 Examples</a> |
+<a href="https://seleniumbase.io/examples/ReadMe/">👨‍🏫 Examples</a> |
 <a href="https://seleniumbase.io/help_docs/mobile_testing/">📱 Mobile</a>
 <br />
-<a href="https://seleniumbase.io/help_docs/syntax_formats/">🔡 Syntax Formats</a> |
+<a href="https://seleniumbase.io/help_docs/syntax_formats/">🔠 Syntax Formats</a> |
 <a href="https://seleniumbase.io/integrations/github/workflows/ReadMe/">🤖 CI</a>
 <br />
-<a href="https://seleniumbase.io/help_docs/method_summary/">📗 API</a> |
-<a href="https://seleniumbase.io/examples/example_logs/ReadMe/">📋 Reports</a> |
+<a href="https://seleniumbase.io/help_docs/method_summary/">📚 API</a> |
+<a href="https://seleniumbase.io/examples/example_logs/ReadMe/">📊 Reports</a> |
 <a href="https://seleniumbase.io/examples/tour_examples/ReadMe/">🗺️ Tours</a>
 <br />
-<a href="https://seleniumbase.io/seleniumbase/console_scripts/ReadMe/">💻 Console Scripts</a> |
+<a href="https://seleniumbase.io/seleniumbase/console_scripts/ReadMe/">🧙‍ Console Scripts</a> |
 <a href="https://seleniumbase.io/seleniumbase/utilities/selenium_grid/ReadMe/">🌐 Grid</a>
 <br />
 <a href="https://github.com/seleniumbase/SeleniumBase/tree/master/examples/boilerplates">♻️ Boilerplates</a> |
 <a href="https://seleniumbase.io/help_docs/locale_codes/">🗾 Locales</a>
 <br />
-<a href="https://seleniumbase.io/help_docs/js_package_manager/">🗄️ PkgManager</a> |
+<a href="https://seleniumbase.io/help_docs/js_package_manager/">🕹️ JSManager</a> |
 <a href="https://seleniumbase.io/examples/visual_testing/ReadMe/">🖼️ VisualTest</a>
 <br />
 <a href="https://seleniumbase.io/help_docs/translations/">🌏 Translate</a> |
-<a href="https://seleniumbase.io/examples/master_qa/ReadMe/">🛂 MasterQA</a>
+<a href="https://seleniumbase.io/examples/dialog_boxes/ReadMe/">🛂 DialogBoxes</a>
 <br />
 <a href="https://seleniumbase.io/seleniumbase/utilities/selenium_ide/ReadMe/">⏺️ Recorder</a> |
 <a href="https://github.com/seleniumbase/SeleniumBase/tree/master/integrations/node_js">🏃 NodeRunner</a>
 <br />
-<a href="https://seleniumbase.io/examples/presenter/ReadMe/">📑 Presenter</a> |
-<a href="https://seleniumbase.io/examples/chart_maker/ReadMe/">📊 ChartMaker</a>
+<a href="https://seleniumbase.io/examples/presenter/ReadMe/">📰 Presenter</a> |
+<a href="https://seleniumbase.io/examples/chart_maker/ReadMe/">📶 ChartMaker</a>
 </p>
 
 --------

--- a/help_docs/features_list.md
+++ b/help_docs/features_list.md
@@ -28,16 +28,16 @@
 * Has a [global config file](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/config/settings.py) for configuring settings as needed.
 * Includes a tool for [creating interactive web presentations](https://github.com/seleniumbase/SeleniumBase/blob/master/examples/presenter/ReadMe.md).
 * Includes [Chart Maker](https://github.com/seleniumbase/SeleniumBase/blob/master/examples/chart_maker/ReadMe.md), a tool for creating interactive charts.
+* Includes a [dialog box builder](https://github.com/seleniumbase/SeleniumBase/blob/master/examples/dialog_boxes/ReadMe.md) to allow user-input during automation.
 * Includes a [website tour builder](https://github.com/seleniumbase/SeleniumBase/blob/master/examples/tour_examples/ReadMe.md) for creating interactive walkthroughs.
-* Has a tool to [export Katalon Recorder scripts into SeleniumBase format](https://github.com/seleniumbase/SeleniumBase/blob/master/integrations/katalon/ReadMe.md).
+* Includes integrations for [GitHub Actions](https://seleniumbase.io/integrations/github/workflows/ReadMe/), [Google Cloud](https://github.com/seleniumbase/SeleniumBase/tree/master/integrations/google_cloud/ReadMe.md), [Azure](https://github.com/seleniumbase/SeleniumBase/blob/master/integrations/azure/jenkins/ReadMe.md), [S3](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/plugins/s3_logging_plugin.py), and [Docker](https://github.com/seleniumbase/SeleniumBase/blob/master/integrations/docker/ReadMe.md).
 * Can handle Google Authenticator logins with [Python's one-time password library](https://pyotp.readthedocs.io/en/latest/).
 * Can load and make assertions on PDF files from websites or the local file system.
 * Is backwards-compatible with Python [WebDriver](https://www.selenium.dev/projects/) methods. (Use: ``self.driver``)
 * Can execute JavaScript code from Python calls. (Use: ``self.execute_script()``)
 * Can pierce through Shadow DOM selectors. (Add ``::shadow`` to CSS fragments.)
-* Includes integrations for [MySQL](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/core/testcase_manager.py), [Selenium Grid](https://github.com/seleniumbase/SeleniumBase/tree/master/seleniumbase/utilities/selenium_grid), [Azure](https://github.com/seleniumbase/SeleniumBase/blob/master/integrations/azure/jenkins/ReadMe.md), [GCP](https://github.com/seleniumbase/SeleniumBase/tree/master/integrations/google_cloud/ReadMe.md), [AWS](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/plugins/s3_logging_plugin.py), and [Docker](https://github.com/seleniumbase/SeleniumBase/blob/master/integrations/docker/ReadMe.md).
 * Includes a hybrid-automation solution, [MasterQA](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/masterqa/ReadMe.md), for speeding up manual testing.
-* Includes a tool for [converting Selenium IDE recordings](https://github.com/seleniumbase/SeleniumBase/tree/master/seleniumbase/utilities/selenium_ide) into SeleniumBase scripts.
+* Includes a tool to [convert Katalon & Selenium IDE recordings](https://github.com/seleniumbase/SeleniumBase/blob/master/integrations/katalon/ReadMe.md) into SeleniumBase scripts.
 * Includes useful [Python decorators and password obfuscation methods](https://github.com/seleniumbase/SeleniumBase/blob/master/seleniumbase/common/ReadMe.md).
 
 --------

--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -69,6 +69,8 @@ self.is_element_enabled(selector, by=By.CSS_SELECTOR)
 
 self.is_text_visible(text, selector="html", by=By.CSS_SELECTOR)
 
+self.is_attribute_present(selector, attribute, value=None, by=By.CSS_SELECTOR)
+
 self.is_link_text_visible(link_text)
 
 self.is_partial_link_text_visible(partial_link_text)
@@ -303,7 +305,7 @@ self.get_link_status_code(link, allow_redirects=False, timeout=5)
 
 self.assert_link_status_code_is_not_404(link)
 
-self.assert_no_404_errors(multithreaded=True)
+self.assert_no_404_errors(multithreaded=True, timeout=None)
 # Duplicates: self.assert_no_broken_links(multithreaded=True)
 
 self.print_unique_links_with_status_codes()
@@ -512,7 +514,21 @@ self.play_tour(name=None)
 
 self.export_tour(name=None, filename="my_tour.js", url=None)
 
+############
+
 self.activate_jquery_confirm()
+
+self.set_jqc_theme(theme, color=None, width=None)
+
+self.reset_jqc_theme()
+
+self.get_jqc_button_input(message, buttons, options=None)
+
+self.get_jqc_text_input(message, button=None, options=None)
+
+self.get_jqc_form_inputs(message, buttons, options=None)
+
+############
 
 self.activate_messenger()
 
@@ -610,6 +626,14 @@ self.assert_element_not_visible(selector, by=By.CSS_SELECTOR, timeout=None)
 self.wait_for_text_not_visible(text, selector="html", by=By.CSS_SELECTOR, timeout=None)
 
 self.assert_text_not_visible(text, selector="html", by=By.CSS_SELECTOR, timeout=None)
+
+############
+
+self.wait_for_attribute_not_present(
+    selector, attribute, value=None, by=By.CSS_SELECTOR, timeout=None)
+
+self.assert_attribute_not_present(
+    selector, attribute, value=None, by=By.CSS_SELECTOR, timeout=None)
 
 ############
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,8 +92,9 @@ nav:
     - Locale Codes: help_docs/locale_codes.md
   - JS Generators:
     - Tour Maker: examples/tour_examples/ReadMe.md
-    - Presentation Maker: examples/presenter/ReadMe.md
+    - Dialog Boxes: examples/dialog_boxes/ReadMe.md
     - Chart Maker: help_docs/chart_maker.md
+    - Presentation Maker: examples/presenter/ReadMe.md
   - Integrations:
     - Mobile Testing: help_docs/mobile_testing.md
     - GitHub CI: integrations/github/workflows/ReadMe.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip>=20.3.4;python_version<"3.6"
-pip>=21.2.3;python_version>="3.6"
+pip>=21.2.4;python_version>="3.6"
 packaging>=20.9;python_version<"3.6"
 packaging>=21.0;python_version>="3.6"
 typing-extensions>=3.10.0.0
@@ -15,16 +15,16 @@ sortedcontainers==2.4.0
 certifi>=2021.5.30
 six==1.16.0
 nose==1.3.7
-ipdb==0.13.4;python_version<"3.6"
-ipdb==0.13.9;python_version>="3.6"
+ipdb==0.13.4;python_version<"3.5"
+ipdb==0.13.9;python_version>="3.5"
 parso==0.7.1;python_version<"3.6"
 parso==0.8.2;python_version>="3.6"
 jedi==0.17.2;python_version<"3.6"
 jedi==0.18.0;python_version>="3.6"
 idna==2.10;python_version<"3.6"
 idna==3.2;python_version>="3.6"
-chardet==3.0.4;python_version<"3.6"
-chardet==4.0.0;python_version>="3.6"
+chardet==3.0.4;python_version<"3.5"
+chardet==4.0.0;python_version>="3.5"
 charset-normalizer==2.0.4;python_version>="3.6"
 urllib3==1.26.6
 requests==2.26.0;python_version<"3.5"
@@ -36,8 +36,8 @@ more-itertools==5.0.0;python_version<"3.5"
 more-itertools==8.8.0;python_version>="3.5"
 cssselect==1.1.0
 filelock==3.0.12
-fasteners==0.16;python_version<"3.6"
-fasteners==0.16.3;python_version>="3.6"
+fasteners==0.16;python_version<"3.5"
+fasteners==0.16.3;python_version>="3.5"
 execnet==1.9.0
 pluggy==0.13.1
 py==1.8.1;python_version<"3.5"
@@ -60,24 +60,25 @@ pytest-xdist==2.3.0;python_version>="3.6"
 parameterized==0.8.1
 sbvirtualdisplay==1.0.0
 soupsieve==1.9.6;python_version<"3.5"
-soupsieve==2.0.1;python_version>="3.5" and python_version<"3.6"
+soupsieve==2.1;python_version>="3.5" and python_version<"3.6"
 soupsieve==2.2.1;python_version>="3.6"
 beautifulsoup4==4.9.3
 cryptography==2.9.2;python_version<"3.5"
-cryptography==3.0;python_version>="3.5" and python_version<"3.6"
+cryptography==3.2.1;python_version>="3.5" and python_version<"3.6"
 cryptography==3.4.7;python_version>="3.6"
-pyopenssl==19.1.0;python_version<"3.6"
-pyopenssl==20.0.1;python_version>="3.6"
+pyopenssl==19.1.0;python_version<"3.5"
+pyopenssl==20.0.1;python_version>="3.5"
 pygments==2.5.2;python_version<"3.5"
-pygments==2.9.0;python_version>="3.5"
+pygments==2.10.0;python_version>="3.5"
 traitlets==4.3.3;python_version<"3.7"
 traitlets==5.0.5;python_version>="3.7"
-prompt-toolkit==1.0.18;python_version<"3.6"
-prompt-toolkit==3.0.19;python_version>="3.6"
+prompt-toolkit==1.0.18;python_version<"3.5"
+prompt-toolkit==2.0.10;python_version>="3.5" and python_version<"3.6.2"
+prompt-toolkit==3.0.20;python_version>="3.6.2"
 decorator==4.4.2;python_version<"3.5"
 decorator==5.0.9;python_version>="3.5"
 ipython==5.10.0;python_version<"3.5"
-ipython==6.5.0;python_version>="3.5" and python_version<"3.6"
+ipython==7.9.0;python_version>="3.5" and python_version<"3.6"
 ipython==7.16.1;python_version>="3.6" and python_version<"3.7"
 ipython==7.26.0;python_version>="3.7"
 matplotlib-inline==0.1.2;python_version>="3.7"
@@ -85,7 +86,8 @@ colorama==0.4.4
 platformdirs==2.0.2;python_version<"3.6"
 platformdirs==2.2.0;python_version>="3.6"
 pathlib2==2.3.5;python_version<"3.5"
-importlib-metadata==2.0.0;python_version<"3.6"
+importlib-metadata==2.0.0;python_version<"3.5"
+importlib-metadata==2.1.1;python_version>="3.5" and python_version<"3.6"
 virtualenv>=20.7.2
 pymysql==0.10.1;python_version<"3.6"
 pymysql==1.0.2;python_version>="3.6"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.63.23"
+__version__ = "1.64.0"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -303,6 +303,7 @@ def _set_chrome_options(
     if user_agent:
         chrome_options.add_argument("--user-agent=%s" % user_agent)
     chrome_options.add_argument("--disable-infobars")
+    chrome_options.add_argument("--disable-notifications")
     chrome_options.add_argument("--disable-save-password-bubble")
     chrome_options.add_argument("--disable-single-click-autofill")
     chrome_options.add_argument(
@@ -1248,6 +1249,7 @@ def get_local_driver(
                 abs_path = os.path.abspath(extension_dir)
                 edge_options.add_argument("--load-extension=%s" % abs_path)
             edge_options.add_argument("--disable-infobars")
+            edge_options.add_argument("--disable-notifications")
             edge_options.add_argument("--disable-save-password-bubble")
             edge_options.add_argument("--disable-single-click-autofill")
             edge_options.add_argument(

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -108,6 +108,57 @@ def is_headless_iedriver_on_path():
     return os.path.exists(LOCAL_HEADLESS_IEDRIVER)
 
 
+def _repair_chromedriver(chrome_options, headless_options):
+    import subprocess
+
+    driver = None
+    subprocess.check_call(
+        "sbase install chromedriver 2.44", shell=True
+    )
+    try:
+        driver = webdriver.Chrome(options=headless_options)
+    except Exception:
+        subprocess.check_call(
+            "sbase install chromedriver latest-1", shell=True
+        )
+        return
+    chrome_version = None
+    if "version" in driver.capabilities:
+        chrome_version = driver.capabilities["version"]
+    else:
+        chrome_version = driver.capabilities["browserVersion"]
+    major_chrome_ver = chrome_version.split(".")[0]
+    chrome_dict = driver.capabilities["chrome"]
+    driver.quit()
+    chromedriver_ver = chrome_dict["chromedriverVersion"]
+    chromedriver_ver = chromedriver_ver.split(" ")[0]
+    major_chromedriver_ver = chromedriver_ver.split(".")[0]
+    if major_chromedriver_ver != major_chrome_ver:
+        subprocess.check_call(
+            "sbase install chromedriver %s" % major_chrome_ver,
+            shell=True
+        )
+    return
+
+
+def _mark_chromedriver_repaired():
+    import codecs
+
+    abs_path = os.path.abspath(".")
+    chromedriver_repaired_lock = constants.MultiBrowser.CHROMEDRIVER_REPAIRED
+    file_path = os.path.join(abs_path, chromedriver_repaired_lock)
+    out_file = codecs.open(file_path, "w+", encoding="utf-8")
+    out_file.writelines("")
+    out_file.close()
+
+
+def _was_chromedriver_repaired():
+    abs_path = os.path.abspath(".")
+    chromedriver_repaired_lock = constants.MultiBrowser.CHROMEDRIVER_REPAIRED
+    file_path = os.path.join(abs_path, chromedriver_repaired_lock)
+    return os.path.exists(file_path)
+
+
 def _add_chrome_proxy_extension(
     chrome_options, proxy_string, proxy_user, proxy_pass
 ):
@@ -1426,8 +1477,87 @@ def get_local_driver(
                     print("\nWarning: chromedriver not found. Installing now:")
                     sb_install.main(override="chromedriver")
                     sys.argv = sys_args  # Put back the original sys args
+                else:
+                    import fasteners
+                    from seleniumbase.console_scripts import sb_install
+
+                    chromedriver_fixing_lock = fasteners.InterProcessLock(
+                        constants.MultiBrowser.CHROMEDRIVER_FIXING_LOCK
+                    )
+                    with chromedriver_fixing_lock:
+                        if not is_chromedriver_on_path():
+                            sys_args = sys.argv  # Save a copy of sys args
+                            print(
+                                "\nWarning: chromedriver not found. "
+                                "Installing now:"
+                            )
+                            sb_install.main(override="chromedriver")
+                            sys.argv = sys_args  # Put back original sys args
             if not headless or "linux" not in PLATFORM:
-                return webdriver.Chrome(options=chrome_options)
+                try:
+                    driver = webdriver.Chrome(options=chrome_options)
+                except Exception as e:
+                    auto_upgrade_chromedriver = False
+                    if "This version of ChromeDriver only supports" in e.msg:
+                        auto_upgrade_chromedriver = True
+                    if not auto_upgrade_chromedriver:
+                        raise Exception(e.msg)  # Not an obvious fix. Raise.
+                    else:
+                        pass  # Try upgrading ChromeDriver to match Chrome.
+                    headless = True
+                    headless_options = _set_chrome_options(
+                        browser_name,
+                        downloads_path,
+                        headless,
+                        locale_code,
+                        proxy_string,
+                        proxy_auth,
+                        proxy_user,
+                        proxy_pass,
+                        user_agent,
+                        disable_csp,
+                        enable_ws,
+                        enable_sync,
+                        use_auto_ext,
+                        no_sandbox,
+                        disable_gpu,
+                        incognito,
+                        guest_mode,
+                        devtools,
+                        remote_debug,
+                        swiftshader,
+                        block_images,
+                        chromium_arg,
+                        user_data_dir,
+                        extension_zip,
+                        extension_dir,
+                        servername,
+                        mobile_emulator,
+                        device_width,
+                        device_height,
+                        device_pixel_ratio,
+                    )
+                    args = " ".join(sys.argv)
+                    if ("-n" in sys.argv or " -n=" in args or args == "-c"):
+                        import fasteners
+
+                        chromedriver_fixing_lock = fasteners.InterProcessLock(
+                            constants.MultiBrowser.CHROMEDRIVER_FIXING_LOCK
+                        )
+                        with chromedriver_fixing_lock:
+                            if not _was_chromedriver_repaired():
+                                _repair_chromedriver(
+                                    chrome_options, headless_options
+                                )
+                                _mark_chromedriver_repaired()
+                    else:
+                        if not _was_chromedriver_repaired():
+                            _repair_chromedriver(
+                                chrome_options, headless_options
+                            )
+                        _mark_chromedriver_repaired()
+                    driver = webdriver.Chrome(options=chrome_options)
+                return driver
             else:  # Running headless on Linux
                 try:
                     return webdriver.Chrome(options=chrome_options)

--- a/seleniumbase/core/jqc_helper.py
+++ b/seleniumbase/core/jqc_helper.py
@@ -1,0 +1,338 @@
+"""
+This module contains methods for opening jquery-confirm boxes.
+These helper methods SHOULD NOT be called directly from tests.
+"""
+from seleniumbase.fixtures import constants
+from seleniumbase.fixtures import js_utils
+
+
+form_code = (
+    """'<form align="center" action="" class="jqc_form">' +
+    '<div class="form-group">' +
+    '<input style="font-size:20px; background-color: #f8fdfd; ' +
+    ' width: 84%%; border: 1px solid blue; ' +
+    ' box-shadow:inset 0 0 2px 2px #f4fafa;"' +
+    ' type="text" class="jqc_input" />' +
+    '</div>' +
+    '</form>'"""
+)
+
+
+def jquery_confirm_button_dialog(driver, message, buttons, options=None):
+    js_utils.activate_jquery_confirm(driver)
+    # These defaults will be overwritten later if set
+    theme = constants.JqueryConfirm.DEFAULT_THEME
+    border_color = constants.JqueryConfirm.DEFAULT_COLOR
+    width = constants.JqueryConfirm.DEFAULT_WIDTH
+    if options:
+        for option in options:
+            if option[0].lower() == "theme":
+                theme = option[1]
+            elif option[0].lower() == "color":
+                border_color = option[1]
+            elif option[0].lower() == "width":
+                width = option[1]
+            else:
+                raise Exception('Unknown option: "%s"' % option[0])
+    if not message:
+        message = ""
+    key_row = ""
+    if len(buttons) == 1:  # There's only one button as an option
+        key_row = "keys: ['enter', 'y', '1'],"  # Shortcut: "Enter","Y","1"
+    b_html = (
+        """button_%s: {
+            btnClass: 'btn-%s',
+            text: '<b>%s</b>',
+            %s
+            action: function(){
+                jqc_status = '%s';
+                $jqc_status = jqc_status;
+                jconfirm.lastButtonText = jqc_status;
+            }
+        },"""
+    )
+    all_buttons = ""
+    btn_count = 0
+    for button in buttons:
+        btn_count += 1
+        text = button[0]
+        text = js_utils.escape_quotes_if_needed(text)
+        if len(buttons) > 1 and text.lower() == "yes":
+            key_row = "keys: ['y'],"
+            if btn_count < 10:
+                key_row = "keys: ['y', '%s']," % btn_count
+        elif len(buttons) > 1 and text.lower() == "no":
+            key_row = "keys: ['n'],"
+            if btn_count < 10:
+                key_row = "keys: ['n', '%s']," % btn_count
+        elif len(buttons) > 1:
+            if btn_count < 10:
+                key_row = "keys: ['%s']," % btn_count
+        color = button[1]
+        if not color:
+            color = "blue"
+        new_button = b_html % (btn_count, color, text, key_row, text)
+        all_buttons += new_button
+
+    content = (
+        '<div></div><font color="#0066ee">%s</font>'
+        "" % (message)
+    )
+    content = js_utils.escape_quotes_if_needed(content)
+    overlay_opacity = "0.32"
+    if theme.lower() == "supervan":
+        overlay_opacity = "0.56"
+    if theme.lower() == "bootstrap":
+        overlay_opacity = "0.64"
+    if theme.lower() == "modern":
+        overlay_opacity = "0.5"
+    if theme.lower() == "material":
+        overlay_opacity = "0.4"
+    jqcd = (
+        """jconfirm({
+            boxWidth: '%s',
+            useBootstrap: false,
+            containerFluid: true,
+            bgOpacity: %s,
+            type: '%s',
+            theme: '%s',
+            animationBounce: 1,
+            typeAnimated: true,
+            animation: 'scale',
+            draggable: true,
+            dragWindowGap: 1,
+            container: 'body',
+            title: '%s',
+            content: '<div></div>',
+            buttons: {
+                %s
+            }
+        });"""
+        % (
+            width,
+            overlay_opacity,
+            border_color,
+            theme,
+            content,
+            all_buttons
+        )
+    )
+    driver.execute_script(jqcd)
+
+
+def jquery_confirm_text_dialog(driver, message, button=None, options=None):
+    js_utils.activate_jquery_confirm(driver)
+    # These defaults will be overwritten later if set
+    theme = constants.JqueryConfirm.DEFAULT_THEME
+    border_color = constants.JqueryConfirm.DEFAULT_COLOR
+    width = constants.JqueryConfirm.DEFAULT_WIDTH
+
+    if not message:
+        message = ""
+    if button:
+        if not type(button) is list and not type(button) is tuple:
+            raise Exception('"button" should be a (text, color) tuple!')
+        if len(button) != 2:
+            raise Exception('"button" should be a (text, color) tuple!')
+    else:
+        button = ("Submit", "blue")
+    if options:
+        for option in options:
+            if option[0].lower() == "theme":
+                theme = option[1]
+            elif option[0].lower() == "color":
+                border_color = option[1]
+            elif option[0].lower() == "width":
+                width = option[1]
+            else:
+                raise Exception('Unknown option: "%s"' % option[0])
+    btn_text = button[0]
+    btn_color = button[1]
+    if not btn_color:
+        btn_color = "blue"
+    content = (
+        '<div></div><font color="#0066ee">%s</font>'
+        "" % (message)
+    )
+    content = js_utils.escape_quotes_if_needed(content)
+    overlay_opacity = "0.32"
+    if theme.lower() == "supervan":
+        overlay_opacity = "0.56"
+    if theme.lower() == "bootstrap":
+        overlay_opacity = "0.64"
+    if theme.lower() == "modern":
+        overlay_opacity = "0.5"
+    if theme.lower() == "material":
+        overlay_opacity = "0.4"
+    jqcd = (
+        """jconfirm({
+            boxWidth: '%s',
+            useBootstrap: false,
+            containerFluid: true,
+            bgOpacity: %s,
+            type: '%s',
+            theme: '%s',
+            animationBounce: 1,
+            typeAnimated: true,
+            animation: 'scale',
+            draggable: true,
+            dragWindowGap: 1,
+            container: 'body',
+            title: '%s',
+            content: '<div></div>' +
+            %s,
+            buttons: {
+                formSubmit: {
+                btnClass: 'btn-%s',
+                text: '%s',
+                action: function () {
+                    jqc_input = this.$content.find('.jqc_input').val();
+                    $jqc_input = this.$content.find('.jqc_input').val();
+                    jconfirm.lastInputText = jqc_input;
+                    $jqc_status = '%s';  // There is only one button
+                },
+            },
+            },
+            onContentReady: function () {
+            var jc = this;
+            this.$content.find('form.jqc_form').on('submit', function (e) {
+                // User submits the form by pressing "Enter" in the field
+                e.preventDefault();
+                jc.$$formSubmit.trigger('click');  // Click the button
+            });
+            }
+        });"""
+        % (
+            width,
+            overlay_opacity,
+            border_color,
+            theme,
+            content,
+            form_code,
+            btn_color,
+            btn_text,
+            btn_text
+        )
+    )
+    driver.execute_script(jqcd)
+
+
+def jquery_confirm_full_dialog(driver, message, buttons, options=None):
+    js_utils.activate_jquery_confirm(driver)
+    # These defaults will be overwritten later if set
+    theme = constants.JqueryConfirm.DEFAULT_THEME
+    border_color = constants.JqueryConfirm.DEFAULT_COLOR
+    width = constants.JqueryConfirm.DEFAULT_WIDTH
+
+    if not message:
+        message = ""
+    btn_count = 0
+    b_html = (
+        """button_%s: {
+            btnClass: 'btn-%s',
+            text: '%s',
+            action: function(){
+            jqc_input = this.$content.find('.jqc_input').val();
+            $jqc_input = this.$content.find('.jqc_input').val();
+            jconfirm.lastInputText = jqc_input;
+            $jqc_status = '%s';
+            }
+        },"""
+    )
+    b1_html = (
+            """formSubmit: {
+                btnClass: 'btn-%s',
+                text: '%s',
+                action: function(){
+                jqc_input = this.$content.find('.jqc_input').val();
+                $jqc_input = this.$content.find('.jqc_input').val();
+                jconfirm.lastInputText = jqc_input;
+                jqc_status = '%s';
+                $jqc_status = jqc_status;
+                jconfirm.lastButtonText = jqc_status;
+                }
+            },"""
+        )
+    one_button_trigger = ""
+    if len(buttons) == 1:
+        # If there's only one button, allow form submit with "Enter/Return"
+        one_button_trigger = "jc.$$formSubmit.trigger('click');"
+    all_buttons = ""
+    for button in buttons:
+        text = button[0]
+        text = js_utils.escape_quotes_if_needed(text)
+        color = button[1]
+        if not color:
+            color = "blue"
+        btn_count += 1
+        if len(buttons) == 1:
+            new_button = b1_html % (color, text, text)
+        else:
+            new_button = b_html % (btn_count, color, text, text)
+        all_buttons += new_button
+    if options:
+        for option in options:
+            if option[0].lower() == "theme":
+                theme = option[1]
+            elif option[0].lower() == "color":
+                border_color = option[1]
+            elif option[0].lower() == "width":
+                width = option[1]
+            else:
+                raise Exception('Unknown option: "%s"' % option[0])
+
+    content = (
+        '<div></div><font color="#0066ee">%s</font>'
+        "" % (message)
+    )
+    content = js_utils.escape_quotes_if_needed(content)
+    overlay_opacity = "0.32"
+    if theme.lower() == "supervan":
+        overlay_opacity = "0.56"
+    if theme.lower() == "bootstrap":
+        overlay_opacity = "0.64"
+    if theme.lower() == "modern":
+        overlay_opacity = "0.5"
+    if theme.lower() == "material":
+        overlay_opacity = "0.4"
+    jqcd = (
+        """jconfirm({
+            boxWidth: '%s',
+            useBootstrap: false,
+            containerFluid: true,
+            bgOpacity: %s,
+            type: '%s',
+            theme: '%s',
+            animationBounce: 1,
+            typeAnimated: true,
+            animation: 'scale',
+            draggable: true,
+            dragWindowGap: 1,
+            container: 'body',
+            title: '%s',
+            content: '<div></div>' +
+            %s,
+            buttons: {
+                %s
+            },
+            onContentReady: function () {
+            var jc = this;
+            this.$content.find('form.jqc_form').on('submit', function (e) {
+                // User submits the form by pressing "Enter" in the field
+                e.preventDefault();
+                %s
+            });
+            }
+        });"""
+        % (
+            width,
+            overlay_opacity,
+            border_color,
+            theme,
+            content,
+            form_code,
+            all_buttons,
+            one_button_trigger
+        )
+    )
+    driver.execute_script(jqcd)

--- a/seleniumbase/core/style_sheet.py
+++ b/seleniumbase/core/style_sheet.py
@@ -1,10 +1,7 @@
 title = """<meta id="OGTitle" property="og:title" content="SeleniumBase">
     <title>Test Report</title>
     <link rel="SHORTCUT ICON"
-    href="%s" /> """ % (
-    "https://raw.githubusercontent.com/seleniumbase/SeleniumBase"
-    "/master/seleniumbase/resources/favicon.ico"
-)
+    href="https://seleniumbase.io/img/favicon.ico" /> """
 
 style = (
     title

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -776,6 +776,18 @@ class BaseCase(unittest.TestCase):
         selector, by = self.__recalculate_selector(selector, by)
         return page_actions.is_text_visible(self.driver, text, selector, by)
 
+    def is_attribute_present(
+        self, selector, attribute, value=None, by=By.CSS_SELECTOR
+    ):
+        """Returns True if the element attribute/value is found.
+        If the value is not specified, the attribute only needs to exist."""
+        self.wait_for_ready_state_complete()
+        time.sleep(0.01)
+        selector, by = self.__recalculate_selector(selector, by)
+        return page_actions.is_attribute_present(
+            self.driver, selector, attribute, value, by
+        )
+
     def is_link_text_visible(self, link_text):
         self.wait_for_ready_state_complete()
         time.sleep(0.01)

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -7499,6 +7499,36 @@ class BaseCase(unittest.TestCase):
 
     ############
 
+    def wait_for_attribute_not_present(
+        self, selector, attribute, value=None, by=By.CSS_SELECTOR, timeout=None
+    ):
+        self.__check_scope()
+        if not timeout:
+            timeout = settings.LARGE_TIMEOUT
+        if self.timeout_multiplier and timeout == settings.LARGE_TIMEOUT:
+            timeout = self.__get_new_timeout(timeout)
+        selector, by = self.__recalculate_selector(selector, by)
+        return page_actions.wait_for_attribute_not_present(
+            self.driver, selector, attribute, value, by, timeout
+        )
+
+    def assert_attribute_not_present(
+        self, selector, attribute, value=None, by=By.CSS_SELECTOR, timeout=None
+    ):
+        """Similar to wait_for_attribute_not_present()
+        Raises an exception if the attribute is still present after timeout.
+        Returns True if successful. Default timeout = SMALL_TIMEOUT."""
+        self.__check_scope()
+        if not timeout:
+            timeout = settings.SMALL_TIMEOUT
+        if self.timeout_multiplier and timeout == settings.SMALL_TIMEOUT:
+            timeout = self.__get_new_timeout(timeout)
+        return self.wait_for_attribute_not_present(
+            selector, attribute, value=value, by=by, timeout=timeout
+        )
+
+    ############
+
     def wait_for_and_accept_alert(self, timeout=None):
         self.__check_scope()
         if not timeout:

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -7486,7 +7486,7 @@ class BaseCase(unittest.TestCase):
         self, text, selector="html", by=By.CSS_SELECTOR, timeout=None
     ):
         """Similar to wait_for_text_not_visible()
-        Raises an exception if the element or the text is not found.
+        Raises an exception if the text is still visible after timeout.
         Returns True if successful. Default timeout = SMALL_TIMEOUT."""
         self.__check_scope()
         if not timeout:

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -8584,10 +8584,11 @@ class BaseCase(unittest.TestCase):
         # Verify that SeleniumBase is installed successfully
         if not hasattr(self, "browser"):
             raise Exception(
-                """SeleniumBase plugins DID NOT load!\n\n"""
-                """*** Please REINSTALL SeleniumBase using: >\n"""
-                """    >>> "pip install -r requirements.txt"\n"""
-                """    >>> "python setup.py install" """
+                'SeleniumBase plugins DID NOT load! * Please REINSTALL!\n'
+                '*** Either install SeleniumBase in Dev Mode from a clone:\n'
+                '    >>> "pip install -e ."     (Run in DIR with setup.py)\n'
+                '*** Or install the latest SeleniumBase version from PyPI:\n'
+                '    >>> "pip install -U seleniumbase"    (Run in any DIR)'
             )
 
         if not hasattr(sb_config, "_is_timeout_changed"):

--- a/seleniumbase/fixtures/constants.py
+++ b/seleniumbase/fixtures/constants.py
@@ -290,6 +290,9 @@ class JqueryConfirm:
         "https://cdnjs.cloudflare.com/ajax/libs/"
         "jquery-confirm/%s/jquery-confirm.min.js" % VER
     )
+    DEFAULT_THEME = "bootstrap"
+    DEFAULT_COLOR = "blue"
+    DEFAULT_WIDTH = "38%"
 
 
 class Shepherd:

--- a/seleniumbase/fixtures/constants.py
+++ b/seleniumbase/fixtures/constants.py
@@ -48,6 +48,11 @@ class Dashboard:
     DASH_PIE_PNG_3 = encoded_images.DASH_PIE_PNG_3  # Faster than CDN
 
 
+class MultiBrowser:
+    CHROMEDRIVER_FIXING_LOCK = Files.DOWNLOADS_FOLDER + "/driver_fixing.lock"
+    CHROMEDRIVER_REPAIRED = Files.DOWNLOADS_FOLDER + "/driver_fixed.lock"
+
+
 class SavedCookies:
     STORAGE_FOLDER = "saved_cookies"
 

--- a/seleniumbase/fixtures/page_actions.py
+++ b/seleniumbase/fixtures/page_actions.py
@@ -106,6 +106,37 @@ def is_text_visible(driver, text, selector, by=By.CSS_SELECTOR):
         return False
 
 
+def is_attribute_present(
+    driver, selector, attribute, value=None, by=By.CSS_SELECTOR
+):
+    """
+    Returns whether the specified attribute is present in the given selector.
+    @Params
+    driver - the webdriver object (required)
+    selector - the locator for identifying the page element (required)
+    attribute - the attribute that is expected for the element (required)
+    value - the attribute value that is expected (Default: None)
+    by - the type of selector being used (Default: By.CSS_SELECTOR)
+    @Returns
+    Boolean (is attribute present)
+    """
+    try:
+        element = driver.find_element(by=by, value=selector)
+        found_value = element.get_attribute(attribute)
+        if found_value is None:
+            raise Exception()
+
+        if value is not None:
+            if found_value == value:
+                return True
+            else:
+                raise Exception()
+        else:
+            return True
+    except Exception:
+        return False
+
+
 def hover_on_element(driver, selector, by=By.CSS_SELECTOR):
     """
     Fires the hover event for the specified element by the given selector.

--- a/seleniumbase/fixtures/page_actions.py
+++ b/seleniumbase/fixtures/page_actions.py
@@ -524,7 +524,7 @@ def wait_for_attribute(
     attribute - the attribute that is expected for the element (required)
     value - the attribute value that is expected (Default: None)
     by - the type of selector being used (Default: By.CSS_SELECTOR)
-    timeout - the time to wait for elements in seconds
+    timeout - the time to wait for the element attribute in seconds
     @Returns
     A web element object that contains the expected attribute/value
     """
@@ -698,6 +698,55 @@ def wait_for_text_not_visible(
         timeout,
         plural,
     )
+    timeout_exception(Exception, message)
+
+
+def wait_for_attribute_not_present(
+    driver,
+    selector,
+    attribute,
+    value=None,
+    by=By.CSS_SELECTOR,
+    timeout=settings.LARGE_TIMEOUT
+):
+    """
+    Searches for the specified element attribute by the given selector.
+    Returns True if the attribute isn't present on the page within the timeout.
+    Also returns True if the element is not present within the timeout.
+    Raises an exception if the attribute is still present after the timeout.
+    @Params
+    driver - the webdriver object (required)
+    selector - the locator for identifying the page element (required)
+    attribute - the element attribute (required)
+    value - the attribute value (Default: None)
+    by - the type of selector being used (Default: By.CSS_SELECTOR)
+    timeout - the time to wait for the element attribute in seconds
+    """
+    start_ms = time.time() * 1000.0
+    stop_ms = start_ms + (timeout * 1000.0)
+    for x in range(int(timeout * 10)):
+        s_utils.check_if_time_limit_exceeded()
+        if not is_attribute_present(
+            driver, selector, attribute, value=value, by=by
+        ):
+            return True
+        now_ms = time.time() * 1000.0
+        if now_ms >= stop_ms:
+            break
+        time.sleep(0.1)
+    plural = "s"
+    if timeout == 1:
+        plural = ""
+    message = (
+        "Attribute {%s} of element {%s} was still present after %s second%s!"
+        "" % (attribute, selector, timeout, plural)
+    )
+    if value:
+        message = (
+            "Value {%s} for attribute {%s} of element {%s} was still present "
+            "after %s second%s!"
+            "" % (value, attribute, selector, timeout, plural)
+        )
     timeout_exception(Exception, message)
 
 

--- a/seleniumbase/fixtures/page_utils.py
+++ b/seleniumbase/fixtures/page_utils.py
@@ -68,7 +68,7 @@ def is_name_selector(selector):
     """
     A basic method to determine if a selector is a name selector.
     """
-    if selector.startswith("name="):
+    if selector.startswith("name=") or selector.startswith("&"):
         return True
     return False
 
@@ -110,7 +110,9 @@ def get_name_from_selector(selector):
     A basic method to get the name from a name selector.
     """
     if selector.startswith("name="):
-        return selector.split("name=")[1]
+        return selector[len("name="):]
+    if selector.startswith("&"):
+        return selector[len("&"):]
     return selector
 
 

--- a/seleniumbase/fixtures/page_utils.py
+++ b/seleniumbase/fixtures/page_utils.py
@@ -56,6 +56,9 @@ def is_partial_link_text_selector(selector):
         selector.startswith("partial_link=")
         or selector.startswith("partial_link_text=")
         or selector.startswith("partial_text=")
+        or selector.startswith("p_link=")
+        or selector.startswith("p_link_text=")
+        or selector.startswith("p_text=")
     ):
         return True
     return False

--- a/seleniumbase/fixtures/page_utils.py
+++ b/seleniumbase/fixtures/page_utils.py
@@ -78,11 +78,11 @@ def get_link_text_from_selector(selector):
     A basic method to get the link text from a link text selector.
     """
     if selector.startswith("link="):
-        return selector.split("link=")[1]
+        return selector[len("link="):]
     elif selector.startswith("link_text="):
-        return selector.split("link_text=")[1]
+        return selector[len("link_text="):]
     elif selector.startswith("text="):
-        return selector.split("text=")[1]
+        return selector[len("text="):]
     return selector
 
 
@@ -91,11 +91,17 @@ def get_partial_link_text_from_selector(selector):
     A basic method to get the partial link text from a partial link selector.
     """
     if selector.startswith("partial_link="):
-        return selector.split("partial_link=")[1]
+        return selector[len("partial_link="):]
     elif selector.startswith("partial_link_text="):
-        return selector.split("partial_link_text=")[1]
+        return selector[len("partial_link_text="):]
     elif selector.startswith("partial_text="):
-        return selector.split("partial_text=")[1]
+        return selector[len("partial_text="):]
+    elif selector.startswith("p_link="):
+        return selector[len("p_link="):]
+    elif selector.startswith("p_link_text="):
+        return selector[len("p_link_text="):]
+    elif selector.startswith("p_text="):
+        return selector[len("p_text="):]
     return selector
 
 

--- a/seleniumbase/masterqa/master_qa.py
+++ b/seleniumbase/masterqa/master_qa.py
@@ -139,18 +139,22 @@ class MasterQA(BaseCase):
                     title: '%s',
                     content: '',
                     buttons: {
-                        fail_button: {
-                            btnClass: 'btn-red',
-                            text: 'NO / FAIL',
-                            action: function(){
-                                $jqc_status = "Failure!"
-                            }
-                        },
                         pass_button: {
                             btnClass: 'btn-green',
                             text: 'YES / PASS',
+                            keys: ['y', 'p', '1'],
                             action: function(){
-                                $jqc_status = "Success!"
+                                $jqc_status = "Success!";
+                                jconfirm.lastButtonText = "Success!";
+                            }
+                        },
+                        fail_button: {
+                            btnClass: 'btn-red',
+                            text: 'NO / FAIL',
+                            keys: ['n', 'f', '2'],
+                            action: function(){
+                                $jqc_status = "Failure!";
+                                jconfirm.lastButtonText = "Failure!";
                             }
                         }
                     }
@@ -210,12 +214,7 @@ class MasterQA(BaseCase):
             try:
                 status = self.execute_script("return $jqc_status")
             except Exception:
-                status = "Failure!"
-                pre_status = self.execute_script(
-                    "return jconfirm.lastClicked.hasClass('btn-green')"
-                )
-                if pre_status:
-                    status = "Success!"
+                status = self.execute_script("return jconfirm.lastButtonText")
         else:
             # Fallback to plain js confirm dialogs if can't load jquery_confirm
             if self.browser == "ie":

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -804,6 +804,7 @@ def pytest_addoption(parser):
                 maximized.""",
     )
     parser.addoption(
+        "--screenshot",
         "--save_screenshot",
         "--save-screenshot",
         action="store_true",

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -561,6 +561,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--slow_mode",
         "--slow-mode",
+        "--slowmo",
         "--slow",
         action="store_true",
         dest="slow_mode",

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -530,6 +530,7 @@ class SeleniumBrowser(Plugin):
             help="""The option to start with the web browser maximized.""",
         )
         parser.add_option(
+            "--screenshot",
             "--save_screenshot",
             "--save-screenshot",
             action="store_true",

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -321,6 +321,7 @@ class SeleniumBrowser(Plugin):
         parser.add_option(
             "--slow_mode",
             "--slow-mode",
+            "--slowmo",
             "--slow",
             action="store_true",
             dest="slow_mode",

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
         'pip>=20.3.4;python_version<"3.6"',
-        'pip>=21.2.3;python_version>="3.6"',
+        'pip>=21.2.4;python_version>="3.6"',
         'packaging>=20.9;python_version<"3.6"',
         'packaging>=21.0;python_version>="3.6"',
         "typing-extensions>=3.10.0.0",
@@ -130,16 +130,16 @@ setup(
         "certifi>=2021.5.30",
         "six==1.16.0",
         "nose==1.3.7",
-        'ipdb==0.13.4;python_version<"3.6"',
-        'ipdb==0.13.9;python_version>="3.6"',
+        'ipdb==0.13.4;python_version<"3.5"',
+        'ipdb==0.13.9;python_version>="3.5"',
         'parso==0.7.1;python_version<"3.6"',
         'parso==0.8.2;python_version>="3.6"',
         'jedi==0.17.2;python_version<"3.6"',
         'jedi==0.18.0;python_version>="3.6"',
         'idna==2.10;python_version<"3.6"',  # Must stay in sync with "requests"
         'idna==3.2;python_version>="3.6"',  # Must stay in sync with "requests"
-        'chardet==3.0.4;python_version<"3.6"',  # Stay in sync with "requests"
-        'chardet==4.0.0;python_version>="3.6"',  # Stay in sync with "requests"
+        'chardet==3.0.4;python_version<"3.5"',  # Stay in sync with "requests"
+        'chardet==4.0.0;python_version>="3.5"',  # Stay in sync with "requests"
         'charset-normalizer==2.0.4;python_version>="3.6"',  # Sync "requests"
         "urllib3==1.26.6",  # Must stay in sync with "requests"
         'requests==2.26.0;python_version<"3.5"',
@@ -151,8 +151,8 @@ setup(
         'more-itertools==8.8.0;python_version>="3.5"',
         "cssselect==1.1.0",
         "filelock==3.0.12",
-        'fasteners==0.16;python_version<"3.6"',
-        'fasteners==0.16.3;python_version>="3.6"',
+        'fasteners==0.16;python_version<"3.5"',
+        'fasteners==0.16.3;python_version>="3.5"',
         "execnet==1.9.0",
         "pluggy==0.13.1",
         'py==1.8.1;python_version<"3.5"',
@@ -175,24 +175,25 @@ setup(
         "parameterized==0.8.1",
         "sbvirtualdisplay==1.0.0",
         'soupsieve==1.9.6;python_version<"3.5"',
-        'soupsieve==2.0.1;python_version>="3.5" and python_version<"3.6"',
+        'soupsieve==2.1;python_version>="3.5" and python_version<"3.6"',
         'soupsieve==2.2.1;python_version>="3.6"',
         "beautifulsoup4==4.9.3",
         'cryptography==2.9.2;python_version<"3.5"',
-        'cryptography==3.0;python_version>="3.5" and python_version<"3.6"',
+        'cryptography==3.2.1;python_version>="3.5" and python_version<"3.6"',
         'cryptography==3.4.7;python_version>="3.6"',
-        'pyopenssl==19.1.0;python_version<"3.6"',
-        'pyopenssl==20.0.1;python_version>="3.6"',
+        'pyopenssl==19.1.0;python_version<"3.5"',
+        'pyopenssl==20.0.1;python_version>="3.5"',
         'pygments==2.5.2;python_version<"3.5"',
-        'pygments==2.9.0;python_version>="3.5"',
+        'pygments==2.10.0;python_version>="3.5"',
         'traitlets==4.3.3;python_version<"3.7"',
         'traitlets==5.0.5;python_version>="3.7"',
-        'prompt-toolkit==1.0.18;python_version<"3.6"',
-        'prompt-toolkit==3.0.19;python_version>="3.6"',
+        'prompt-toolkit==1.0.18;python_version<"3.5"',
+        'prompt-toolkit==2.0.10;python_version>="3.5" and python_version<"3.6.2"',  # noqa: E501
+        'prompt-toolkit==3.0.20;python_version>="3.6.2"',
         'decorator==4.4.2;python_version<"3.5"',
         'decorator==5.0.9;python_version>="3.5"',
         'ipython==5.10.0;python_version<"3.5"',
-        'ipython==6.5.0;python_version>="3.5" and python_version<"3.6"',
+        'ipython==7.9.0;python_version>="3.5" and python_version<"3.6"',
         'ipython==7.16.1;python_version>="3.6" and python_version<"3.7"',
         'ipython==7.26.0;python_version>="3.7"',
         'matplotlib-inline==0.1.2;python_version>="3.7"',
@@ -200,7 +201,8 @@ setup(
         'platformdirs==2.0.2;python_version<"3.6"',
         'platformdirs==2.2.0;python_version>="3.6"',
         'pathlib2==2.3.5;python_version<"3.5"',  # Sync with "virtualenv"
-        'importlib-metadata==2.0.0;python_version<"3.6"',  # Sync "virtualenv"
+        'importlib-metadata==2.0.0;python_version<"3.5"',
+        'importlib-metadata==2.1.1;python_version>="3.5" and python_version<"3.6"',  # noqa: E501
         "virtualenv>=20.7.2",  # Sync with importlib-metadata and pathlib2
         'pymysql==0.10.1;python_version<"3.6"',
         'pymysql==1.0.2;python_version>="3.6"',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if sys.argv[-1] == "publish":
         print("\n*** Installing twine: *** (Required for PyPI uploads)\n")
         os.system("python -m pip install --upgrade 'twine>=1.15.0'")
         print("\n*** Installing tqdm: *** (Required for PyPI uploads)\n")
-        os.system("python -m pip install --upgrade 'tqdm>=4.62.0'")
+        os.system("python -m pip install --upgrade 'tqdm>=4.62.2'")
         print("\n*** Publishing The Release to PyPI: ***\n")
         os.system("python -m twine upload dist/*")  # Requires ~/.pypirc Keys
         print("\n*** The Release was PUBLISHED SUCCESSFULLY to PyPI! :) ***\n")


### PR DESCRIPTION
## Dialog Boxes and more

* Add New Feature: SeleniumBase Dialog Boxes.
* Add custom timeout option for ``self.assert_no_404_errors()``.
* Add a default Chromium option for disabling notifications.
* Auto-repair ChromeDriver to sync with Chrome (Mac/Win only).
* Add ``self.is_attribute_present(selector, attribute, value)``.
* Update the error message for fixing a SeleniumBase install.
* Add ``self.wait_for_attribute_not_present()``.
* Add ``self.assert_attribute_not_present()``.
* Add keyboard shortcuts to MasterQA mode.
* Add "--slowmo" as an alternative to "--slow-mode".
* Add "--screenshot" as an alternative to "--save-screenshot".
* Update the favicon link in generated reports.
* Add additional shortcuts for partial_link_text selectors.
* Update methods for getting the link text from selectors.
* Add "&" as a shortcut for a single-syllable "name" selector.
* Update Python dependencies.


<h2><img src="https://seleniumbase.io/img/logo6.png" title="SeleniumBase" width="32" /> 🛂 Dialog Boxes 🛂</h2>

SeleniumBase Dialog Boxes let your users provide input in the middle of automation scripts.

* This feature utilizes the [jquery-confirm](https://craftpip.github.io/jquery-confirm/) library.
* A Python API is used to call the JavaScript API.

<img src="https://seleniumbase.io/cdn/img/emoji_sports_dialog.png" alt="SeleniumBase" width="440" />

<h4>↕️ (<a href="https://github.com/seleniumbase/SeleniumBase/blob/master/examples/dialog_boxes/dialog_box_tour.py">Example: dialog_box_tour.py</a>) ↕️</h4>

<img src="https://seleniumbase.io/cdn/gif/sports_dialog.gif" alt="SeleniumBase" width="440" />

<h4>Here's how to run that example:</h4>

```bash
cd examples/dialog_boxes
pytest test_dialog_boxes.py
```

<h4>Here's a code snippet from that:</h4>

```python
self.open("https://xkcd.com/1920/")
skip_button = ["SKIP", "red"]  # Can be a [text, color] list or tuple.
buttons = ["Fencing", "Football", "Metaball", "Go/Chess", skip_button]
message = "Choose a sport:"
choice = self.get_jqc_button_input(message, buttons)
if choice == "Fencing":
    self.open("https://xkcd.com/1424/")
```

* You can create forms that include buttons and input fields.

<h4>Here's a simple form with only buttons as input:</h4>

```python
choice = self.get_jqc_button_input("Ready?", ["YES", "NO"])
print(choice)  # This prints "YES" or "NO"

# You may want to customize the color of buttons:
buttons = [("YES", "green"), ("NO", "red")]
choice = self.get_jqc_button_input("Ready?", buttons)
```

<h4>Here's a simple form with an input field:</h4>

```python
text = self.get_jqc_text_input("Enter text:", ["Search"])
print(text)  # This prints the text entered
```

<h4>This form has an input field and buttons:</h4>

```python
message = "Type your name and choose a language:"
buttons = ["Python", "JavaScript"]
text, choice = self.get_jqc_form_inputs(message, buttons)
print("Your name is: %s" % text)
print("You picked %s!" % choice)
```

<h4>You can customize options if you want:</h4>

```python
# Themes: bootstrap, modern, material, supervan, light, dark, seamless
options = [("theme", "modern"), ("width", "50%")]
self.get_jqc_text_input("You Won!", ["OK"], options)
```

<h4>Default options can be set with <code>set_jqc_theme()</code>:</h4>

```python
self.set_jqc_theme("light", color="green", width="38%")

# To reset jqc theme settings to factory defaults:
self.reset_jqc_theme()
```

<h3>All methods for Dialog Boxes:</h3>

```python
self.get_jqc_button_input(message, buttons, options=None)

self.get_jqc_text_input(message, button=None, options=None)

self.get_jqc_form_inputs(message, buttons, options=None)

self.set_jqc_theme(theme, color=None, width=None)

self.reset_jqc_theme()

self.activate_jquery_confirm()  # Automatic for jqc methods
```

<h3>Detailed method summaries for Dialog Boxes:</h3>

```python
self.get_jqc_button_input(message, buttons, options=None)
"""
Pop up a jquery-confirm box and return the text of the button clicked.
If running in headless mode, the last button text is returned.
@Params
message: The message to display in the jquery-confirm dialog.
buttons: A list of tuples for text and color.
    Example: [("Yes!", "green"), ("No!", "red")]
    Available colors: blue, green, red, orange, purple, default, dark.
    A simple text string also works: "My Button". (Uses default color.)
options: A list of tuples for options to set.
    Example: [("theme", "bootstrap"), ("width", "450px")]
    Available theme options: bootstrap, modern, material, supervan,
                             light, dark, and seamless.
    Available colors: (For the BORDER color, NOT the button color.)
        "blue", "default", "green", "red", "purple", "orange", "dark".
    Example option for changing the border color: ("color", "default")
    Width can be set using percent or pixels. Eg: "36.0%", "450px".
"""

self.get_jqc_text_input(message, button=None, options=None)
"""
Pop up a jquery-confirm box and return the text submitted by the input.
If running in headless mode, the text returned is "" by default.
@Params
message: The message to display in the jquery-confirm dialog.
button: A 2-item list or tuple for text and color. Or just the text.
    Example: ["Submit", "blue"] -> (default button if not specified)
    Available colors: blue, green, red, orange, purple, default, dark.
    A simple text string also works: "My Button". (Uses default color.)
options: A list of tuples for options to set.
    Example: [("theme", "bootstrap"), ("width", "450px")]
    Available theme options: bootstrap, modern, material, supervan,
                             light, dark, and seamless.
    Available colors: (For the BORDER color, NOT the button color.)
        "blue", "default", "green", "red", "purple", "orange", "dark".
    Example option for changing the border color: ("color", "default")
    Width can be set using percent or pixels. Eg: "36.0%", "450px".
"""

self.get_jqc_form_inputs(message, buttons, options=None)
"""
Pop up a jquery-confirm box and return the input/button texts as tuple.
If running in headless mode, returns the ("", buttons[-1][0]) tuple.
@Params
message: The message to display in the jquery-confirm dialog.
buttons: A list of tuples for text and color.
    Example: [("Yes!", "green"), ("No!", "red")]
    Available colors: blue, green, red, orange, purple, default, dark.
    A simple text string also works: "My Button". (Uses default color.)
options: A list of tuples for options to set.
    Example: [("theme", "bootstrap"), ("width", "450px")]
    Available theme options: bootstrap, modern, material, supervan,
                             light, dark, and seamless.
    Available colors: (For the BORDER color, NOT the button color.)
        "blue", "default", "green", "red", "purple", "orange", "dark".
    Example option for changing the border color: ("color", "default")
    Width can be set using percent or pixels. Eg: "36.0%", "450px".
"""

self.set_jqc_theme(theme, color=None, width=None)
""" Sets the default jquery-confirm theme and width (optional).
Available themes: "bootstrap", "modern", "material", "supervan",
                  "light", "dark", and "seamless".
Available colors: (This sets the BORDER color, NOT the button color.)
    "blue", "default", "green", "red", "purple", "orange", "dark".
Width can be set using percent or pixels. Eg: "36.0%", "450px".
"""

self.reset_jqc_theme()
""" Resets the jqc theme settings to factory defaults. """

self.activate_jquery_confirm()  # Automatic for jqc methods
""" See https://craftpip.github.io/jquery-confirm/ for usage. """
```

--------

<h4>✅ 🛂 Automated/Manual Hybrid Mode (MasterQA)</h4>
<p><b><a href="https://seleniumbase.io/seleniumbase/masterqa/ReadMe/">MasterQA</a></b> uses <b>SeleniumBase Dialog Boxes</b> to speed up manual testing by having automation perform all the browser actions while the manual tester handles validation. See <a href="https://github.com/seleniumbase/SeleniumBase/tree/master/examples/master_qa">the MasterQA GitHub page</a> for examples.</p>
