### PR TITLE
Fix & update the automatic ChromeDriver repair/upgrade script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ soupsieve==2.2.1;python_version>="3.6"
 beautifulsoup4==4.9.3
 cryptography==2.9.2;python_version<"3.5"
 cryptography==3.2.1;python_version>="3.5" and python_version<"3.6"
-cryptography==3.4.7;python_version>="3.6"
+cryptography==3.4.8;python_version>="3.6"
 pyopenssl==19.1.0;python_version<"3.5"
 pyopenssl==20.0.1;python_version>="3.5"
 pygments==2.5.2;python_version<"3.5"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.64.0"
+__version__ = "1.64.1"

--- a/seleniumbase/console_scripts/sb_install.py
+++ b/seleniumbase/console_scripts/sb_install.py
@@ -447,7 +447,7 @@ def main(override=None):
 
     file_path = downloads_folder + "/" + file_name
     if not os.path.exists(downloads_folder):
-        os.mkdir(downloads_folder)
+        os.makedirs(downloads_folder)
 
     if headless_ie_exists:
         headless_ie_file_path = downloads_folder + "/" + headless_ie_file_name

--- a/seleniumbase/console_scripts/sb_mkdir.py
+++ b/seleniumbase/console_scripts/sb_mkdir.py
@@ -401,7 +401,7 @@ def main():
     data.append("        [")
     data.append('            ["pypi", "pypi.org"],')
     data.append('            ["wikipedia", "wikipedia.org"],')
-    data.append('            ["seleniumbase", "seleniumbase/SeleniumBase"],')
+    data.append('            ["seleniumbase", "SeleniumBase"],')
     data.append("        ]")
     data.append("    )")
     data.append(

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -147,6 +147,9 @@ def _mark_chromedriver_repaired():
     abs_path = os.path.abspath(".")
     chromedriver_repaired_lock = constants.MultiBrowser.CHROMEDRIVER_REPAIRED
     file_path = os.path.join(abs_path, chromedriver_repaired_lock)
+    downloads_folder = download_helper.get_downloads_folder()
+    if not os.path.exists(downloads_folder):
+        os.makedirs(downloads_folder)
     out_file = codecs.open(file_path, "w+", encoding="utf-8")
     out_file.writelines("")
     out_file.close()

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -1503,6 +1503,8 @@ def get_local_driver(
                     auto_upgrade_chromedriver = False
                     if "This version of ChromeDriver only supports" in e.msg:
                         auto_upgrade_chromedriver = True
+                    elif "Chrome version must be between" in e.msg:
+                        auto_upgrade_chromedriver = True
                     if not auto_upgrade_chromedriver:
                         raise Exception(e.msg)  # Not an obvious fix. Raise.
                     else:

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ setup(
         "beautifulsoup4==4.9.3",
         'cryptography==2.9.2;python_version<"3.5"',
         'cryptography==3.2.1;python_version>="3.5" and python_version<"3.6"',
-        'cryptography==3.4.7;python_version>="3.6"',
+        'cryptography==3.4.8;python_version>="3.6"',
         'pyopenssl==19.1.0;python_version<"3.5"',
         'pyopenssl==20.0.1;python_version>="3.5"',
         'pygments==2.5.2;python_version<"3.5"',


### PR DESCRIPTION
### Fix & update the automatic ChromeDriver repair/upgrade script
* Fix the automatic chromedriver repair/upgrade script:
-- A folder might need to be created first in some scenarios.
* Auto-upgrade chromedriver on ``"version must be between"``:
-- Previously, only on ``"This version of ChromeDriver only supports"``.
* Refresh Python dependencies:
-- ``cryptography==3.4.8;python_version>="3.6"``
* Update a test created by ``sbase mkdir DIR``.