### PR TITLE
Change how headless Firefox runs on Linux

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "1.65.0"
+__version__ = "1.65.1"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -519,7 +519,7 @@ def _set_firefox_options(
     options.set_preference(
         "browser.download.manager.showAlertOnComplete", False
     )
-    if headless:
+    if headless and "linux" not in PLATFORM:
         options.add_argument("--headless")
     if locale_code:
         options.set_preference("intl.accept_languages", locale_code)


### PR DESCRIPTION
### Change how headless Firefox runs on Linux
* This reverts a change made in version ``1.65.0``.
-- The old way (and now) may need Xvfb installed.