### PR TITLE
Update Recorder Mode script-generation

### DIFF
--- a/help_docs/recorder_mode.md
+++ b/help_docs/recorder_mode.md
@@ -6,7 +6,7 @@
 
 <img src="https://seleniumbase.io/cdn/img/sb_recorder_notification.png" title="SeleniumBase" width="380">
 
-(This tutorial assumes that you are using SeleniumBase version ``2.1.3`` or newer.)
+(This tutorial assumes that you are using SeleniumBase version ``2.1.5`` or newer.)
 
 🔴 To make a new recording with Recorder Mode, you can use ``sbase mkrec`` or ``sbase codegen``):
 

--- a/mkdocs_build/requirements.txt
+++ b/mkdocs_build/requirements.txt
@@ -1,4 +1,4 @@
-regex>=2021.11.2
+regex>=2021.11.9
 tqdm>=4.62.3
 docutils==0.18
 python-dateutil==2.8.2
@@ -9,12 +9,12 @@ MarkupSafe==2.0.1;python_version>="3.6"
 pyparsing==2.4.7;python_version>="3.6"
 keyring==23.2.1;python_version>="3.6"
 pkginfo==1.7.1;python_version>="3.6"
-Jinja2==3.0.2;python_version>="3.6"
+Jinja2==3.0.3;python_version>="3.6"
 click==8.0.3;python_version>="3.6"
 zipp==3.6.0;python_version>="3.6"
 readme-renderer==30.0
 pymdown-extensions==9.0;python_version>="3.6"
-importlib-metadata==4.8.1;python_version>="3.6"
+importlib-metadata==4.8.2;python_version>="3.6"
 bleach==4.1.0
 jsmin==3.0.0;python_version>="3.6"
 lunr==0.6.1;python_version>="3.6"

--- a/mkdocs_build/requirements.txt
+++ b/mkdocs_build/requirements.txt
@@ -1,4 +1,4 @@
-regex>=2021.11.9
+regex>=2021.11.10
 tqdm>=4.62.3
 docutils==0.18
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ trio-websocket==0.9.2;python_version>="3.7"
 pyopenssl==21.0.0;python_version>="3.7"
 msedge-selenium-tools==3.141.3;python_version<"3.7"
 more-itertools==5.0.0;python_version<"3.5"
-more-itertools==8.10.0;python_version>="3.5"
+more-itertools==8.11.0;python_version>="3.5"
 cssselect==1.1.0
 filelock==3.2.1;python_version<"3.6"
 filelock==3.3.2;python_version>="3.6"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "2.1.4"
+__version__ = "2.1.5"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -3312,7 +3312,9 @@ class BaseCase(unittest.TestCase):
                 if (
                     url1 == url2
                     or url1 == url2.replace("www.", "")
-                    or (len(url1) > 0 and url2.startswith(url1))
+                    or (len(url1) > 0 and url2.startswith(url1)
+                        and (int(srt_actions[n][3]) - int(
+                            srt_actions[n-1][3]) < 6500))
                 ):
                     srt_actions[n][0] = "f_url"
         for n in range(len(srt_actions)):

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -3125,7 +3125,7 @@ class BaseCase(unittest.TestCase):
         self.__check_scope()
         if not sb_config.time_limit:
             time.sleep(seconds)
-        elif seconds <= 0.3:
+        elif seconds < 0.4:
             shared_utils.check_if_time_limit_exceeded()
             time.sleep(seconds)
             shared_utils.check_if_time_limit_exceeded()

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -3309,7 +3309,11 @@ class BaseCase(unittest.TestCase):
                     url2 = url1[:-3]
                 elif url2.endswith("/"):
                     url2 = url2[:-1]
-                if (url1 == url2) or (url1 == url2.replace("www.", "")):
+                if (
+                    url1 == url2
+                    or url1 == url2.replace("www.", "")
+                    or (len(url1) > 0 and url2.startswith(url1))
+                ):
                     srt_actions[n][0] = "f_url"
         for n in range(len(srt_actions)):
             if (

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -157,7 +157,14 @@ class BaseCase(unittest.TestCase):
             if ("http:") in c_url or ("https:") in c_url or ("file:") in c_url:
                 if self.get_domain_url(url) != self.get_domain_url(c_url):
                     self.open_new_window(switch_to=True)
-        self.driver.get(url)
+        try:
+            self.driver.get(url)
+        except Exception as e:
+            if "ERR_CONNECTION_TIMED_OUT" in e.msg:
+                self.sleep(0.5)
+                self.driver.get(url)
+            else:
+                raise Exception(e.msg)
         if settings.WAIT_FOR_RSC_ON_PAGE_LOADS:
             self.wait_for_ready_state_complete()
         self.__demo_mode_pause_if_active()

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup(
         'pyopenssl==21.0.0;python_version>="3.7"',
         'msedge-selenium-tools==3.141.3;python_version<"3.7"',
         'more-itertools==5.0.0;python_version<"3.5"',
-        'more-itertools==8.10.0;python_version>="3.5"',
+        'more-itertools==8.11.0;python_version>="3.5"',
         "cssselect==1.1.0",
         'filelock==3.2.1;python_version<"3.6"',
         'filelock==3.3.2;python_version>="3.6"',


### PR DESCRIPTION
### Update Recorder Mode script-generation

This is to prevent a duplicate browser action that can occur when a click redirects to a new URL. The Recorder will record a ``click()`` and an ``open()`` action, but if the click already takes the user to the URL being opened, then the browser does not need to call the ``open()`` action separately, and instead should mask the action with ``open_if_not_url()``. This issue was discovered when clicking a link with ``href="https://en.wikipedia.org/"``, which redirected to ``https://en.wikipedia.org/wiki/Main_Page``.

#### Other changes include:
* Better error-handling for the ``open()`` method.
* Update timing logic for the time-limit feature.
* Refresh Python dependencies:
-- ``more-itertools==8.11.0;python_version>="3.5"``
