### PR TITLE
Make improvements to the "Deferred Assert" system

### DIFF
--- a/examples/test_deferred_asserts.py
+++ b/examples/test_deferred_asserts.py
@@ -2,6 +2,7 @@
 This test demonstrates the use of deferred asserts.
 Deferred asserts won't raise exceptions from failures until either
 process_deferred_asserts() is called, or the test reaches the tearDown() step.
+Requires version 2.1.6 or newer for the deferred_assert_exact_text() method.
 """
 import pytest
 from seleniumbase import BaseCase
@@ -19,4 +20,6 @@ class DeferredAssertTests(BaseCase):
         self.deferred_assert_text("Fake Item", "#middleContainer")  # Will Fail
         self.deferred_assert_text("Random", "#middleContainer")
         self.deferred_assert_element('a[name="Super Fake !!!"]')  # Will Fail
+        self.deferred_assert_exact_text("Brand Identity", "#ctitle")
+        self.deferred_assert_exact_text("Fake Food", "#comic")  # Will Fail
         self.process_deferred_asserts()

--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -692,8 +692,15 @@ self.check_window(
 self.deferred_assert_element(selector, by=By.CSS_SELECTOR, timeout=None)
 # Duplicates: self.delayed_assert_element(selector, by=By.CSS_SELECTOR, timeout=None)
 
-self.deferred_assert_text(text, selector="html", by=By.CSS_SELECTOR, timeout=None)
-# Duplicates: self.delayed_assert_text(text, selector="html", by=By.CSS_SELECTOR, timeout=None)
+self.deferred_assert_text(
+    text, selector="html", by=By.CSS_SELECTOR, timeout=None)
+# Duplicates:
+# self.delayed_assert_text(text, selector="html", by=By.CSS_SELECTOR, timeout=None)
+
+self.deferred_assert_exact_text(
+    text, selector="html", by=By.CSS_SELECTOR, timeout=None)
+# Duplicates:
+# self.delayed_assert_exact_text(text, selector="html", by=By.CSS_SELECTOR, timeout=None)
 
 self.deferred_check_window(
     name="default", level=0, baseline=False, check_domain=True, full_diff=False)

--- a/help_docs/recorder_mode.md
+++ b/help_docs/recorder_mode.md
@@ -6,7 +6,7 @@
 
 <img src="https://seleniumbase.io/cdn/img/sb_recorder_notification.png" title="SeleniumBase" width="380">
 
-(This tutorial assumes that you are using SeleniumBase version ``2.1.5`` or newer.)
+(This tutorial assumes that you are using SeleniumBase version ``2.1.6`` or newer.)
 
 🔴 To make a new recording with Recorder Mode, you can use ``sbase mkrec`` or ``sbase codegen``):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,10 @@ tomli>=1.2.2;python_version>="3.6"
 wheel>=0.37.0
 attrs>=21.2.0
 PyYAML>=6.0;python_version>="3.6"
-sortedcontainers==2.4.0
+traitlets==4.3.3;python_version<"3.7"
+traitlets>=5.1.1;python_version>="3.7"
 certifi>=2021.10.8
+sortedcontainers==2.4.0
 six==1.16.0
 nose==1.3.7
 sniffio;python_version>="3.7"
@@ -79,8 +81,6 @@ cryptography==3.4.8;python_version>="3.6" and python_version<"3.7"
 cryptography==35.0.0;python_version>="3.7"
 pygments==2.5.2;python_version<"3.5"
 pygments==2.10.0;python_version>="3.5"
-traitlets==4.3.3;python_version<"3.7"
-traitlets==5.1.1;python_version>="3.7"
 prompt-toolkit==1.0.18;python_version<"3.5"
 prompt-toolkit==2.0.10;python_version>="3.5" and python_version<"3.6.2"
 prompt-toolkit==3.0.22;python_version>="3.6.2"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "2.1.5"
+__version__ = "2.1.6"

--- a/setup.py
+++ b/setup.py
@@ -128,8 +128,10 @@ setup(
         "wheel>=0.37.0",
         "attrs>=21.2.0",
         'PyYAML>=6.0;python_version>="3.6"',
-        "sortedcontainers==2.4.0",
+        'traitlets==4.3.3;python_version<"3.7"',
+        'traitlets>=5.1.1;python_version>="3.7"',
         "certifi>=2021.10.8",
+        "sortedcontainers==2.4.0",
         "six==1.16.0",
         "nose==1.3.7",
         'sniffio;python_version>="3.7"',  # For "trio". (Funnier under "nose")
@@ -195,8 +197,6 @@ setup(
         'cryptography==35.0.0;python_version>="3.7"',
         'pygments==2.5.2;python_version<"3.5"',
         'pygments==2.10.0;python_version>="3.5"',
-        'traitlets==4.3.3;python_version<"3.7"',
-        'traitlets==5.1.1;python_version>="3.7"',
         'prompt-toolkit==1.0.18;python_version<"3.5"',
         'prompt-toolkit==2.0.10;python_version>="3.5" and python_version<"3.6.2"',  # noqa: E501
         'prompt-toolkit==3.0.22;python_version>="3.6.2"',


### PR DESCRIPTION
### Make improvements to the "Deferred Assert" system

SeleniumBase deferred asserts allow you to make multiple assertions on the same page without failing the test after the first failed assert. Instead, you can choose when to process those assertions by calling: ``self.process_deferred_asserts()``.

* Add ``self.deferred_assert_exact_text()``
-- (This is similar to ``self.deferred_assert_text()``, but text must be ``equal``, instead of ``in``.)
* Fix spacing in the console output of deferred assertion failures.
* This resolves https://github.com/seleniumbase/SeleniumBase/issues/1065
* Example test: https://github.com/seleniumbase/SeleniumBase/blob/master/examples/test_deferred_asserts.py

#### Also refresh Python dependencies:

* ``traitlets`` version now only has a lower bound, instead of an exact version.
-- (For Python versions 3.7 and newer. Earlier Python versions still use a pin.)

```
traitlets==4.3.3;python_version<"3.7"
traitlets>=5.1.1;python_version>="3.7"
```