### PR TITLE
Fix visual tests that use the "sb" fixture (and more!)

### DIFF
--- a/examples/custom_settings.py
+++ b/examples/custom_settings.py
@@ -19,7 +19,7 @@ SWITCH_TO_NEW_TABS_ON_CLICK = True
 
 # Waiting for Document.readyState to be "Complete" after browser actions.
 WAIT_FOR_RSC_ON_PAGE_LOADS = True
-WAIT_FOR_RSC_ON_CLICKS = True
+WAIT_FOR_RSC_ON_CLICKS = False
 WAIT_FOR_ANGULARJS = True
 
 # Changing the default behavior of Demo Mode. Activate with: --demo_mode

--- a/examples/github_test.py
+++ b/examples/github_test.py
@@ -9,14 +9,12 @@ class GitHubTests(BaseCase):
         # To avoid this automation blocker, two steps are being taken:
         # 1. self.slow_click() is being used to slow down Selenium actions.
         # 2. The browser's User Agent is modified to avoid Selenium-detection
-        #    when running in headless mode on Chrome or Edge (Chromium).
-        if self.headless and (
-            self.browser == "chrome" or self.browser == "edge"
-        ):
+        #    when running in headless mode.
+        if self.headless:
             self.get_new_driver(
                 agent="""Mozilla/5.0 """
                 """AppleWebKit/537.36 (KHTML, like Gecko) """
-                """Chrome/92.0.4515.159 Safari/537.36"""
+                """Chrome/Version 96.0.4664.55 Safari/537.36"""
             )
         self.open("https://github.com/search?q=SeleniumBase")
         self.slow_click('a[href="/seleniumbase/SeleniumBase"]')

--- a/examples/handle_alert_test.py
+++ b/examples/handle_alert_test.py
@@ -3,8 +3,6 @@ from seleniumbase import BaseCase
 
 class HandleAlertTests(BaseCase):
     def test_alerts(self):
-        if self.browser == "safari":
-            self.skip("This test doesn't run on Safari! (alert issues)")
         self.open("about:blank")
         self.execute_script('window.alert("ALERT!!!");')
         self.sleep(1)  # Not needed (Lets you see the alert pop up)

--- a/examples/visual_testing/test_layout_fail.py
+++ b/examples/visual_testing/test_layout_fail.py
@@ -1,4 +1,17 @@
+""" Visual Layout Testing with different Syntax Formats """
+
 from seleniumbase import BaseCase
+
+
+class VisualLayout_FixtureTests():
+    def test_python_home_change(sb):
+        sb.open("https://python.org/")
+        print('\nCreating baseline in "visual_baseline" folder.')
+        sb.check_window(name="python_home", baseline=True)
+        # Remove the "Donate" button
+        sb.remove_element("a.donate-button")
+        print("(This test should fail)")  # due to missing button
+        sb.check_window(name="python_home", level=3)
 
 
 class VisualLayoutFailureTests(BaseCase):
@@ -10,17 +23,8 @@ class VisualLayoutFailureTests(BaseCase):
         self.click('a[href="?diff1"]')
         # Click a button that makes a hidden element visible
         self.click("button")
-        print("(This test should fail)")
+        print("(This test should fail)")  # due to image now seen
         self.check_window(name="helloworld", level=3)
-
-    def test_python_home_change(self):
-        self.open("https://python.org/")
-        print('\nCreating baseline in "visual_baseline" folder.')
-        self.check_window(name="python_home", baseline=True)
-        # Remove the "Donate" button
-        self.remove_element("a.donate-button")
-        print("(This test should fail)")
-        self.check_window(name="python_home", level=3)
 
     def test_xkcd_logo_change(self):
         self.open("https://xkcd.com/554/")
@@ -29,5 +33,5 @@ class VisualLayoutFailureTests(BaseCase):
         # Change height: (83 -> 110) , Change width: (185 -> 120)
         self.set_attribute('[alt="xkcd.com logo"]', "height", "110")
         self.set_attribute('[alt="xkcd.com logo"]', "width", "120")
-        print("(This test should fail)")
+        print("(This test should fail)")  # due to a resized logo
         self.check_window(name="xkcd_554", level=3)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ theme:
     # - navigation.sections
     - navigation.expand
     # - navigation.tabs
+    - navigation.top
     - navigation.tracking
     - navigation.instant
   palette:

--- a/mkdocs_build/requirements.txt
+++ b/mkdocs_build/requirements.txt
@@ -21,7 +21,7 @@ lunr==0.6.1;python_version>="3.6"
 nltk==3.6.5;python_version>="3.6"
 watchdog==2.1.6;python_version>="3.6"
 mkdocs==1.2.3;python_version>="3.6"
-mkdocs-material==8.0.2;python_version>="3.6"
+mkdocs-material==8.0.3;python_version>="3.6"
 mkdocs-exclude-search==0.5.4;python_version>="3.6"
 mkdocs-simple-hooks==0.1.3
 mkdocs-material-extensions==1.0.3;python_version>="3.6"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "2.2.5"
+__version__ = "2.2.6"

--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -54,7 +54,7 @@ Setting this to True may improve reliability at the cost of speed.
 # Called after self.open(url) or self.open_url(url), NOT self.driver.open(url)
 WAIT_FOR_RSC_ON_PAGE_LOADS = True
 # Called after self.click(selector), NOT element.click()
-WAIT_FOR_RSC_ON_CLICKS = True
+WAIT_FOR_RSC_ON_CLICKS = False
 
 """
 This adds wait_for_angularjs() after various browser actions.

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -139,6 +139,11 @@ class BaseCase(unittest.TestCase):
         """ Navigates the current browser window to the specified page. """
         self.__check_scope()
         self.__check_browser()
+        pre_action_url = None
+        try:
+            pre_action_url = self.driver.current_url
+        except Exception:
+            pass
         if type(url) is str:
             url = url.strip()  # Remove leading and trailing whitespace
         if (type(url) is not str) or not self.__looks_like_a_page_url(url):
@@ -170,6 +175,11 @@ class BaseCase(unittest.TestCase):
                 self.driver.get(url)
             else:
                 raise Exception(e.msg)
+        if (
+            self.driver.current_url == pre_action_url
+            and pre_action_url != url
+        ):
+            time.sleep(0.1)  # Make sure load happens
         if settings.WAIT_FOR_RSC_ON_PAGE_LOADS:
             self.wait_for_ready_state_complete()
         self.__demo_mode_pause_if_active()

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -9555,12 +9555,15 @@ class BaseCase(unittest.TestCase):
         test_logpath = os.path.join(self.log_path, self.__get_test_id())
         for baseline_copy_tuple in self.__visual_baseline_copies:
             baseline_path = baseline_copy_tuple[0]
-            baseline_copy_path = baseline_copy_tuple[1]
-            b_c_alt_path = baseline_copy_tuple[2]
+            baseline_copy_name = baseline_copy_tuple[1]
+            b_c_alt_name = baseline_copy_tuple[2]
             latest_png_path = baseline_copy_tuple[3]
-            latest_copy_path = baseline_copy_tuple[4]
-            l_c_alt_path = baseline_copy_tuple[5]
-
+            latest_copy_name = baseline_copy_tuple[4]
+            l_c_alt_name = baseline_copy_tuple[5]
+            baseline_copy_path = os.path.join(test_logpath, baseline_copy_name)
+            b_c_alt_path = os.path.join(test_logpath, b_c_alt_name)
+            latest_copy_path = os.path.join(test_logpath, latest_copy_name)
+            l_c_alt_path = os.path.join(test_logpath, l_c_alt_name)
             if len(self.__visual_baseline_copies) == 1:
                 baseline_copy_path = b_c_alt_path
                 latest_copy_path = l_c_alt_path
@@ -9798,19 +9801,14 @@ class BaseCase(unittest.TestCase):
             out_file.writelines(json.dumps(level_3))
             out_file.close()
 
-        test_logpath = os.path.join(self.log_path, self.__get_test_id())
         baseline_path = os.path.join(visual_baseline_path, baseline_png)
         baseline_copy_name = "baseline_%s.png" % name
-        baseline_copy_path = os.path.join(test_logpath, baseline_copy_name)
         b_c_alt_name = "baseline.png"
-        b_c_alt_path = os.path.join(test_logpath, b_c_alt_name)
         latest_copy_name = "baseline_diff_%s.png" % name
-        latest_copy_path = os.path.join(test_logpath, latest_copy_name)
         l_c_alt_name = "baseline_diff.png"
-        l_c_alt_path = os.path.join(test_logpath, l_c_alt_name)
         baseline_copy_tuple = (
-            baseline_path, baseline_copy_path, b_c_alt_path,
-            latest_png_path, latest_copy_path, l_c_alt_path,
+            baseline_path, baseline_copy_name, b_c_alt_name,
+            latest_png_path, latest_copy_name, l_c_alt_name,
         )
         self.__visual_baseline_copies.append(baseline_copy_tuple)
 

--- a/seleniumbase/fixtures/js_utils.py
+++ b/seleniumbase/fixtures/js_utils.py
@@ -247,6 +247,11 @@ def wait_for_css_query_selector(
 
 
 def highlight_with_js(driver, selector, loops, o_bs):
+    try:
+        # This closes any pop-up alerts
+        driver.execute_script("")
+    except Exception:
+        pass
     script = (
         """document.querySelector('%s').style.boxShadow =
         '0px 0px 6px 6px rgba(128, 128, 128, 0.5)';"""
@@ -308,6 +313,11 @@ def highlight_with_js(driver, selector, loops, o_bs):
 
 
 def highlight_with_jquery(driver, selector, loops, o_bs):
+    try:
+        # This closes any pop-up alerts
+        driver.execute_script("")
+    except Exception:
+        pass
     script = (
         """jQuery('%s').css('box-shadow',
         '0px 0px 6px 6px rgba(128, 128, 128, 0.5)');"""
@@ -689,6 +699,11 @@ def post_messenger_error_message(driver, message, msg_dur):
 
 
 def highlight_with_js_2(driver, message, selector, o_bs, msg_dur):
+    try:
+        # This closes any pop-up alerts
+        driver.execute_script("")
+    except Exception:
+        pass
     if selector == "html":
         selector = "body"
     script = (


### PR DESCRIPTION
### Fix visual tests that use the "sb" fixture (and more!)
* Fix log path issue with visual tests that use the ``sb`` fixture.
* Handle a possible edge case with page loads.
* Make sure highlighting isn't blocked by pop-up alerts.
* Set ``WAIT_FOR_RSC_ON_CLICKS`` to be ``False`` by default.
--  Tests will be faster, but you may need to manually call ``self.accept_alert()`` or ``self.dismiss_alert()`` because previously, waiting for the ``readyState`` of the page to be "complete" might have dismissed alerts automatically due to an existing WebDriver "feature" where calling ``self.execute_script("")`` automatically closes pop-up alerts.