### PR TITLE
Expose the proxy bypass option

### DIFF
--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -253,6 +253,7 @@ def _set_chrome_options(
     proxy_auth,
     proxy_user,
     proxy_pass,
+    proxy_bypass_list,
     user_agent,
     recorder_ext,
     disable_csp,
@@ -441,6 +442,9 @@ def _set_chrome_options(
                 chrome_options, proxy_string, proxy_user, proxy_pass
             )
         chrome_options.add_argument("--proxy-server=%s" % proxy_string)
+        if proxy_bypass_list:
+            chrome_options.add_argument(
+                "--proxy-bypass-list=%s" % proxy_bypass_list)
     if headless:
         if not proxy_auth and not browser_name == constants.Browser.OPERA:
             # Headless Chrome doesn't support extensions, which are
@@ -491,6 +495,7 @@ def _set_firefox_options(
     headless,
     locale_code,
     proxy_string,
+    proxy_bypass_list,
     user_agent,
     disable_csp,
     firefox_arg,
@@ -545,6 +550,8 @@ def _set_firefox_options(
             options.set_preference("network.proxy.http_port", int(proxy_port))
             options.set_preference("network.proxy.ssl", proxy_server)
             options.set_preference("network.proxy.ssl_port", int(proxy_port))
+        if proxy_bypass_list:
+            options.set_preference("no_proxies_on", proxy_bypass_list)
     if user_agent:
         options.set_preference("general.useragent.override", user_agent)
     options.set_preference(
@@ -697,6 +704,7 @@ def get_driver(
     servername="localhost",
     port=4444,
     proxy_string=None,
+    proxy_bypass_list=None,
     user_agent=None,
     cap_file=None,
     cap_string=None,
@@ -771,6 +779,7 @@ def get_driver(
             proxy_auth,
             proxy_user,
             proxy_pass,
+            proxy_bypass_list,
             user_agent,
             cap_file,
             cap_string,
@@ -810,6 +819,7 @@ def get_driver(
             proxy_auth,
             proxy_user,
             proxy_pass,
+            proxy_bypass_list,
             user_agent,
             recorder_ext,
             disable_csp,
@@ -849,6 +859,7 @@ def get_remote_driver(
     proxy_auth,
     proxy_user,
     proxy_pass,
+    proxy_bypass_list,
     user_agent,
     cap_file,
     cap_string,
@@ -940,6 +951,7 @@ def get_remote_driver(
             proxy_auth,
             proxy_user,
             proxy_pass,
+            proxy_bypass_list,
             user_agent,
             recorder_ext,
             disable_csp,
@@ -1007,6 +1019,7 @@ def get_remote_driver(
             headless,
             locale_code,
             proxy_string,
+            proxy_bypass_list,
             user_agent,
             disable_csp,
             firefox_arg,
@@ -1245,6 +1258,7 @@ def get_local_driver(
     proxy_auth,
     proxy_user,
     proxy_pass,
+    proxy_bypass_list,
     user_agent,
     recorder_ext,
     disable_csp,
@@ -1283,6 +1297,7 @@ def get_local_driver(
             headless,
             locale_code,
             proxy_string,
+            proxy_bypass_list,
             user_agent,
             disable_csp,
             firefox_arg,
@@ -1539,6 +1554,9 @@ def get_local_driver(
                     edge_options, proxy_string, proxy_user, proxy_pass
                 )
             edge_options.add_argument("--proxy-server=%s" % proxy_string)
+        if proxy_bypass_list:
+            edge_options.add_argument(
+                "--proxy-bypass-list=%s" % proxy_bypass_list)
         edge_options.add_argument("--test-type")
         edge_options.add_argument("--log-level=3")
         edge_options.add_argument("--no-first-run")
@@ -1682,6 +1700,7 @@ def get_local_driver(
                 proxy_auth,
                 proxy_user,
                 proxy_pass,
+                proxy_bypass_list,
                 user_agent,
                 recorder_ext,
                 disable_csp,
@@ -1734,6 +1753,7 @@ def get_local_driver(
                 proxy_auth,
                 proxy_user,
                 proxy_pass,
+                proxy_bypass_list,
                 user_agent,
                 recorder_ext,
                 disable_csp,
@@ -1830,6 +1850,7 @@ def get_local_driver(
                         proxy_auth,
                         proxy_user,
                         proxy_pass,
+                        proxy_bypass_list,
                         user_agent,
                         recorder_ext,
                         disable_csp,

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2644,6 +2644,7 @@ class BaseCase(unittest.TestCase):
         servername=None,
         port=None,
         proxy=None,
+        proxy_bypass_list=None,
         agent=None,
         switch_to=True,
         cap_file=None,
@@ -2685,6 +2686,8 @@ class BaseCase(unittest.TestCase):
         servername - if using a Selenium Grid, set the host address here
         port - if using a Selenium Grid, set the host port here
         proxy - if using a proxy server, specify the "host:port" combo here
+        proxy_bypass_list - Semi-colon  seperated string of domains to not
+                            use a proxy for or * to bypass all
         switch_to - the option to switch to the new driver (default = True)
         cap_file - the file containing desired capabilities for the browser
         cap_string - the string with desired capabilities for the browser
@@ -2759,6 +2762,8 @@ class BaseCase(unittest.TestCase):
         proxy_string = proxy
         if proxy_string is None:
             proxy_string = self.proxy_string
+        if proxy_bypass_list is None:
+            proxy_bypass_list = self.proxy_bypass_list
         user_agent = agent
         if user_agent is None:
             user_agent = self.user_agent
@@ -2833,6 +2838,7 @@ class BaseCase(unittest.TestCase):
             servername=servername,
             port=port,
             proxy_string=proxy_string,
+            proxy_bypass_list=proxy_bypass_list,
             user_agent=user_agent,
             cap_file=cap_file,
             cap_string=cap_string,
@@ -10563,6 +10569,7 @@ class BaseCase(unittest.TestCase):
             self.servername = sb_config.servername
             self.port = sb_config.port
             self.proxy_string = sb_config.proxy_string
+            self.proxy_bypass_list = sb_config.proxy_bypass_list
             self.user_agent = sb_config.user_agent
             self.mobile_emulator = sb_config.mobile_emulator
             self.device_metrics = sb_config.device_metrics
@@ -10843,6 +10850,7 @@ class BaseCase(unittest.TestCase):
                 servername=self.servername,
                 port=self.port,
                 proxy=self.proxy_string,
+                proxy_bypass_list=self.proxy_bypass_list,
                 agent=self.user_agent,
                 switch_to=True,
                 cap_file=self.cap_file,

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -37,6 +37,8 @@ def pytest_addoption(parser):
     --cap-string=STRING  (The web browser's desired capabilities to use.)
     --proxy=SERVER:PORT  (Connect to a proxy server:port for tests.)
     --proxy=USERNAME:PASSWORD@SERVER:PORT  (Use authenticated proxy server.)
+    --proxy-bypass-list=STRING (Semi-colon  seperated string of domains to not
+                                use a proxy for or * to bypass all)
     --agent=STRING  (Modify the web browser's User-Agent string.)
     --mobile  (Use the mobile device emulator while running tests.)
     --metrics=STRING  (Set mobile metrics: "CSSWidth,CSSHeight,PixelRatio".)
@@ -383,6 +385,17 @@ def pytest_addoption(parser):
                 username:password@servername:port  OR
                 A dict key from proxy_list.PROXY_LIST
                 Default: None.""",
+    )
+    parser.addoption(
+        "--proxy-bypass-list",
+        action="store",
+        dest="proxy_bypass_list",
+        default=None,
+        help="""Designates the domains or IP address to bypass the defined proxy.
+                Format: example.test  OR
+                example.test,anothorexample.test  OR
+                *
+                Default: ''.""",
     )
     parser.addoption(
         "--agent",
@@ -1051,6 +1064,7 @@ def pytest_configure(config):
         if str(sb_config.port) == "443":
             sb_config.protocol = "https"
     sb_config.proxy_string = config.getoption("proxy_string")
+    sb_config.proxy_bypass_list = config.getoption("proxy_bypass_list")
     sb_config.cap_file = config.getoption("cap_file")
     sb_config.cap_string = config.getoption("cap_string")
     sb_config.settings_file = config.getoption("settings_file")

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -21,6 +21,8 @@ class SeleniumBrowser(Plugin):
     --cap-string=STRING  (The web browser's desired capabilities to use.)
     --proxy=SERVER:PORT  (Connect to a proxy server:port for tests.)
     --proxy=USERNAME:PASSWORD@SERVER:PORT  (Use authenticated proxy server.)
+    --proxy-bypass-list=STRING (Semi-colon seperated string of domains to not
+                                use a proxy for or * to bypass all)
     --agent=STRING  (Modify the web browser's User-Agent string.)
     --mobile  (Use the mobile device emulator while running tests.)
     --metrics=STRING  (Set mobile metrics: "CSSWidth,CSSHeight,PixelRatio".)
@@ -156,6 +158,17 @@ class SeleniumBrowser(Plugin):
                             username:password@servername:port  OR
                             A dict key from proxy_list.PROXY_LIST
                     Default: None.""",
+        )
+        parser.add_option(
+            "--proxy-bypass-list",
+            action="store",
+            dest="proxy_bypass_list",
+            default=None,
+            help="""Designates the domains or IP address to bypass the defined proxy.
+                    Format: example.test  OR
+                    example.test,anothorexample.test  OR
+                    *
+                    Default: ''.""",
         )
         parser.add_option(
             "--agent",
@@ -625,6 +638,7 @@ class SeleniumBrowser(Plugin):
         test.test.firefox_arg = self.options.firefox_arg
         test.test.firefox_pref = self.options.firefox_pref
         test.test.proxy_string = self.options.proxy_string
+        test.test.proxy_bypass_list = self.options.proxy_bypass_list
         test.test.user_agent = self.options.user_agent
         test.test.mobile_emulator = self.options.mobile_emulator
         test.test.device_metrics = self.options.device_metrics


### PR DESCRIPTION
In some scenarios there will be a mixture of requests some will need a proxy some won't. This adds and exposes the proxy bypass option.

I have only tested this in chrome on linux, can you help by suggesting:

- What tests need to be added.
- Documentation to be added.
- Updates for other browsers.