### PR TITLE
Perform Windows and Edge optimizations

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "2.4.22"
+__version__ = "2.4.23"

--- a/seleniumbase/console_scripts/ReadMe.md
+++ b/seleniumbase/console_scripts/ReadMe.md
@@ -60,7 +60,7 @@ sbase install chromedriver latest
 sbase install chromedriver latest-1  # (Latest minus one)
 sbase install chromedriver -p
 sbase install chromedriver latest -p
-sbase install edgedriver 99.0.1150.39
+sbase install edgedriver 99.0.1150.46
 ```
 
 (Drivers:  ``chromedriver``, ``geckodriver``, ``edgedriver``,

--- a/seleniumbase/console_scripts/run.py
+++ b/seleniumbase/console_scripts/run.py
@@ -135,7 +135,7 @@ def show_install_usage():
     print("           sbase install chromedriver latest-1")
     print("           sbase install chromedriver -p")
     print("           sbase install chromedriver latest -p")
-    print("           sbase install edgedriver 99.0.1150.39")
+    print("           sbase install edgedriver 99.0.1150.46")
     print("  Output:")
     print("           Installs the chosen webdriver to seleniumbase/drivers/")
     print("           (chromedriver is required for Chrome automation)")

--- a/seleniumbase/console_scripts/sb_install.py
+++ b/seleniumbase/console_scripts/sb_install.py
@@ -19,7 +19,7 @@ Example:
         sbase install chromedriver latest-1  # (Latest minus one)
         sbase install chromedriver -p
         sbase install chromedriver latest -p
-        sbase install edgedriver 99.0.1150.39
+        sbase install edgedriver 99.0.1150.46
 Output:
         Installs the chosen webdriver to seleniumbase/drivers/
         (chromedriver is required for Chrome automation)
@@ -71,7 +71,7 @@ def invalid_run_command():
     exp += "          sbase install chromedriver latest-1\n"
     exp += "          sbase install chromedriver -p\n"
     exp += "          sbase install chromedriver latest -p\n"
-    exp += "          sbase install edgedriver 99.0.1150.39"
+    exp += "          sbase install edgedriver 99.0.1150.46"
     exp += "  Output:\n"
     exp += "          Installs the chosen webdriver to seleniumbase/drivers/\n"
     exp += "          (chromedriver is required for Chrome automation)\n"

--- a/seleniumbase/console_scripts/sb_install.py
+++ b/seleniumbase/console_scripts/sb_install.py
@@ -45,7 +45,7 @@ DRIVER_DIR = os.path.dirname(os.path.realpath(drivers.__file__))
 LOCAL_PATH = "/usr/local/bin/"  # On Mac and Linux systems
 DEFAULT_CHROMEDRIVER_VERSION = "2.44"  # (Specify "latest" to get the latest)
 DEFAULT_GECKODRIVER_VERSION = "v0.30.0"
-DEFAULT_EDGEDRIVER_VERSION = "99.0.1150.39"  # (Looks for LATEST_STABLE first)
+DEFAULT_EDGEDRIVER_VERSION = "99.0.1150.46"  # (Looks for LATEST_STABLE first)
 DEFAULT_OPERADRIVER_VERSION = "v.96.0.4664.45"
 
 

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -68,6 +68,9 @@ logging.getLogger("requests").setLevel(logging.ERROR)
 logging.getLogger("urllib3").setLevel(logging.ERROR)
 urllib3.disable_warnings()
 LOGGER.setLevel(logging.WARNING)
+is_windows = False
+if sys.platform in ["win32", "win64", "x64"]:
+    is_windows = True
 python3 = True
 if sys.version_info[0] < 3:
     python3 = False
@@ -9979,7 +9982,8 @@ class BaseCase(unittest.TestCase):
                 "Use this method only if get_new_driver() has been called."
             )
         try:
-            driver.quit()
+            if not is_windows or driver.service.process:
+                driver.quit()
         except AttributeError:
             pass
         except Exception:
@@ -11666,7 +11670,8 @@ class BaseCase(unittest.TestCase):
         self._drivers_list.reverse()  # Last In, First Out
         for driver in self._drivers_list:
             try:
-                driver.quit()
+                if not is_windows or driver.service.process:
+                    driver.quit()
             except AttributeError:
                 pass
             except Exception:

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -10,6 +10,9 @@ from seleniumbase import config as sb_config
 from seleniumbase.config import settings
 from seleniumbase.fixtures import constants
 
+is_windows = False
+if sys.platform in ["win32", "win64", "x64"]:
+    is_windows = True
 pytest_plugins = ["pytester"]  # Adds the "testdir" fixture
 
 
@@ -1349,7 +1352,8 @@ def pytest_runtest_teardown(item):
                 and self.driver
                 and "--pdb" not in sys.argv
             ):
-                self.driver.quit()
+                if not is_windows or self.driver.service.process:
+                    self.driver.quit()
         except Exception:
             pass
         try:
@@ -1402,7 +1406,8 @@ def _perform_pytest_unconfigure_():
         # Close the shared browser session
         if sb_config.shared_driver:
             try:
-                sb_config.shared_driver.quit()
+                if not is_windows or sb_config.shared_driver.service.process:
+                    sb_config.shared_driver.quit()
             except AttributeError:
                 pass
             except Exception:

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -8,6 +8,10 @@ from seleniumbase.config import settings
 from seleniumbase.core import proxy_helper
 from seleniumbase.fixtures import constants
 
+is_windows = False
+if sys.platform in ["win32", "win64", "x64"]:
+    is_windows = True
+
 
 class SeleniumBrowser(Plugin):
     """
@@ -744,7 +748,8 @@ class SeleniumBrowser(Plugin):
     def afterTest(self, test):
         try:
             # If the browser window is still open, close it now.
-            self.driver.quit()
+            if not is_windows or self.driver.service.process:
+                self.driver.quit()
         except AttributeError:
             pass
         except Exception:


### PR DESCRIPTION
### Perform Windows and Edge optimizations
* [Check for service process before driver.quit() on Windows](https://github.com/seleniumbase/SeleniumBase/commit/91c76462e7955e8aac1c5a3ce6c8722eba3d4468)
-- (This prevents a hanging process during cleanup if a driver was already quit. Sometimes people forget that SeleniumBase already quits drivers automatically at the end of tests, so if they manually try to quit a driver during a test, then during the cleanup phase there would be a hanging process on Windows when SeleniumBase tries to quit the driver again. Now, a check is performed to find out if drivers have already been quit.)
-- (In the case of tests that spin up multiple drivers using ``self.get_new_driver()``, in SeleniumBase ``2.4.22``, a new method was added: ``self.quit_extra_driver()``, which quits extra drivers safely, and then removes those drivers from the list of drivers to be quit automatically at the end of tests.)
* [Update default EdgeDriver version if can't detect latest](https://github.com/seleniumbase/SeleniumBase/commit/41ba3f4702c16bfbb42c87d6e02abb6f7193fbe2)