### PR TITLE
Add a shortcut for cycling through elements with the "tab" key and then clicking the active element

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install --upgrade wheel
         pip install -r requirements.txt
     - name: Install SeleniumBase
       run: |

--- a/examples/test_cycle_elements.py
+++ b/examples/test_cycle_elements.py
@@ -1,0 +1,13 @@
+from seleniumbase import BaseCase
+
+
+class CycleTests(BaseCase):
+    def test_cycle_elements_with_tab_and_press_enter(self):
+        """ Test pressing the tab key to cycle through elements.
+            Then click on the active element and verify actions.
+            This can all be performed by using a single command.
+            The "\t" is the tab key. The "\n" is the RETURN key. """
+        self.open("seleniumbase.io/demo_page")
+        self.assert_text("This Text is Green", "#pText")
+        self.send_keys("html", "\t\t\t\t\n")
+        self.assert_text("This Text is Purple", "#pText")

--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -30,8 +30,8 @@ self.type(selector, text, by="css selector", timeout=None)
 #             self.fill(selector, text, by="css selector", timeout=None)
 #             self.write(selector, text, by="css selector", timeout=None)
 
-self.add_text(selector, text, by="css selector", timeout=None)
-# Duplicates: self.send_keys(selector, text, by="css selector", timeout=None)
+self.send_keys(selector, text, by="css selector", timeout=None)
+# Duplicates: self.add_text(selector, text, by="css selector", timeout=None)
 
 self.submit(selector, by="css selector")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,7 +124,7 @@ toml==0.10.2
 Pillow==6.2.2;python_version<"3.5"
 Pillow==7.2.0;python_version>="3.5" and python_version<"3.6"
 Pillow==8.4.0;python_version>="3.6" and python_version<"3.7"
-Pillow==9.1.1;python_version>="3.7"
+Pillow==9.2.0;python_version>="3.7"
 typing-extensions==3.10.0.2;python_version<"3.6"
 typing-extensions==4.1.1;python_version>="3.6" and python_version<"3.7"
 typing-extensions==4.2.0;python_version>="3.7" and python_version<"3.9"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "3.3.5"
+__version__ = "3.3.6"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -649,9 +649,25 @@ class BaseCase(unittest.TestCase):
         if self.__is_shadow_selector(selector):
             self.__shadow_type(selector, text, timeout, clear_first=False)
             return
+        if selector == "html" and text in ["\n", Keys.ENTER, Keys.RETURN]:
+            # This is a shortcut for calling self.click_active_element().
+            # Use after "\t" or Keys.TAB to cycle through elements first.
+            self.click_active_element()
+            return
         element = self.wait_for_element_visible(
             selector, by=by, timeout=timeout
         )
+        if (
+            selector == "html" and text.count("\t") >= 1
+            and text.count("\n") == 1 and text.endswith("\n")
+            and text.replace("\t", "").replace("\n", "").replace(" ", "") == ""
+        ):
+            # Shortcut to send multiple tabs followed by click_active_element()
+            self.wait_for_ready_state_complete()
+            for tab in range(text.count("\t")):
+                element.send_keys("\t")
+            self.click_active_element()
+            return
         self.__demo_mode_highlight_if_active(selector, by)
         if not self.demo_mode and not self.slow_mode:
             self.__scroll_to_element(element, selector, by)

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -713,6 +713,17 @@ class BaseCase(unittest.TestCase):
         selector, by = self.__recalculate_selector(selector, by)
         self.update_text(selector, text, by=by, timeout=timeout, retry=retry)
 
+    def send_keys(self, selector, text, by="css selector", timeout=None):
+        """Same as self.add_text()
+        Similar to update_text(), but won't clear the text field first."""
+        self.__check_scope()
+        if not timeout:
+            timeout = settings.LARGE_TIMEOUT
+        if self.timeout_multiplier and timeout == settings.LARGE_TIMEOUT:
+            timeout = self.__get_new_timeout(timeout)
+        selector, by = self.__recalculate_selector(selector, by)
+        self.add_text(selector, text, by=by, timeout=timeout)
+
     def submit(self, selector, by="css selector"):
         """Alternative to self.driver.find_element_by_*(SELECTOR).submit()"""
         self.__check_scope()
@@ -7316,16 +7327,6 @@ class BaseCase(unittest.TestCase):
             timeout = self.__get_new_timeout(timeout)
         selector, by = self.__recalculate_selector(selector, by)
         self.update_text(selector, text, by=by, timeout=timeout, retry=retry)
-
-    def send_keys(self, selector, text, by="css selector", timeout=None):
-        """Same as self.add_text()"""
-        self.__check_scope()
-        if not timeout:
-            timeout = settings.LARGE_TIMEOUT
-        if self.timeout_multiplier and timeout == settings.LARGE_TIMEOUT:
-            timeout = self.__get_new_timeout(timeout)
-        selector, by = self.__recalculate_selector(selector, by)
-        self.add_text(selector, text, by=by, timeout=timeout)
 
     def click_link(self, link_text, timeout=None):
         """Same as self.click_link_text()"""

--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,7 @@ setup(
         'Pillow==6.2.2;python_version<"3.5"',
         'Pillow==7.2.0;python_version>="3.5" and python_version<"3.6"',
         'Pillow==8.4.0;python_version>="3.6" and python_version<"3.7"',
-        'Pillow==9.1.1;python_version>="3.7"',
+        'Pillow==9.2.0;python_version>="3.7"',
         'typing-extensions==3.10.0.2;python_version<"3.6"',  # <3.9 for "rich"
         'typing-extensions==4.1.1;python_version>="3.6" and python_version<"3.7"',  # noqa: E501
         'typing-extensions==4.2.0;python_version>="3.7" and python_version<"3.9"',  # noqa: E501


### PR DESCRIPTION
## Add a shortcut for cycling through elements with the "tab" key and then clicking the active element

* [Add a shortcut to tab through and click active elements](https://github.com/seleniumbase/SeleniumBase/commit/36e71ece3401cbbac2ecf1cdd031cac274ec1bbe)
--> This resolves https://github.com/seleniumbase/SeleniumBase/issues/1390

Eg. ``self.send_keys("html", "\t\t\t\t\n")``

This assumes that selector is ``html`` , and that the text is a series of tabs (zero or more ``\t``) followed by one ``\n`` at the end of the string.

Examples:

```python
self.send_keys("html", "\t\t\t\t\n")
self.send_keys("html", "\t\n")
self.send_keys("html", "\n")
```

Another way of clicking the active element right now is by calling:

```python
self.click_active_element()
```