### PR TITLE
Add a Context Manager method for switching into iframes using a "with" statement

### DIFF
--- a/examples/test_iframes.py
+++ b/examples/test_iframes.py
@@ -17,6 +17,19 @@ class FrameTests(BaseCase):
         self.switch_to_frame("iframeResult")  # Go back inside 1st iframe
         self.highlight('iframe[title="Iframe Example"]')
 
+    def test_iframes_with_context_manager(self):
+        self.open("https://seleniumbase.io/w3schools/iframes.html")
+        with self.frame_switch("iframeResult"):
+            self.assert_text("HTML Iframes", "h2")
+            with self.frame_switch('[title*="Iframe"]'):
+                self.assert_text("This page is displayed in an iframe", "h1")
+            self.assert_text("Use CSS width & height to specify", "p")
+            with self.frame_switch('[title*="Iframe"]'):
+                self.assert_text("seleniumbase.io/w3schools/iframes", "a")
+        self.click("button#runbtn")
+        with self.frame_switch("iframeResult"):
+            self.highlight('iframe[title="Iframe Example"]')
+
     def test_set_content_to_frame(self):
         self.open("https://seleniumbase.io/w3schools/iframes.html")
         self.set_content_to_frame("iframeResult")

--- a/help_docs/method_summary.md
+++ b/help_docs/method_summary.md
@@ -209,6 +209,9 @@ self.switch_to_default_content()
 
 self.switch_to_parent_frame()
 
+with self.frame_switch(frame, timeout=None):
+    # Indented Code Block for Context Manager (Must use "with")
+
 self.set_content_to_frame(frame, timeout=None)
 
 self.set_content_to_default(nested=False)

--- a/mkdocs_build/requirements.txt
+++ b/mkdocs_build/requirements.txt
@@ -14,7 +14,7 @@ keyring==23.6.0
 pkginfo==1.8.3
 Jinja2==3.1.2
 click==8.1.3
-zipp==3.8.0
+zipp==3.8.1
 ghp-import==2.1.0
 readme-renderer==35.0
 pymdown-extensions==9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -128,7 +128,7 @@ pdfminer.six==20220524;python_version>="3.7"
 
 coverage==5.5;python_version<"3.6"
 coverage==6.2;python_version>="3.6" and python_version<"3.7"
-coverage==6.4.1;python_version>="3.7"
+coverage==6.4.2;python_version>="3.7"
 pytest-cov==2.12.1;python_version<"3.6"
 pytest-cov==3.0.0;python_version>="3.6"
 flake8==3.7.9;python_version<"3.6"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "3.5.0"
+__version__ = "3.5.1"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -42,6 +42,7 @@ import textwrap
 import time
 import unittest
 import urllib3
+from contextlib import contextmanager
 from selenium.common.exceptions import (
     ElementClickInterceptedException as ECI_Exception,
     ElementNotInteractableException as ENI_Exception,
@@ -2774,6 +2775,18 @@ class BaseCase(unittest.TestCase):
                         self.__extra_actions.append(action)
                         return
         self.driver.switch_to.parent_frame()
+
+    @contextmanager
+    def frame_switch(self, frame, timeout=None):
+        """ Context Manager for switching into iframes.
+        Usage example:
+            with self.frame_switch("iframe"):
+                # Perform actions here that should be done within the iframe.
+            # The iframe is automatically exited after the "with" block ends.
+        """
+        self.switch_to_frame(frame, timeout=timeout)
+        yield
+        self.switch_to_parent_frame()
 
     def set_content_to_frame(self, frame, timeout=None):
         """Replaces the page html with an iframe's html from that page.

--- a/setup.py
+++ b/setup.py
@@ -254,7 +254,7 @@ setup(
         "coverage": [
             'coverage==5.5;python_version<"3.6"',
             'coverage==6.2;python_version>="3.6" and python_version<"3.7"',
-            'coverage==6.4.1;python_version>="3.7"',
+            'coverage==6.4.2;python_version>="3.7"',
             'pytest-cov==2.12.1;python_version<"3.6"',
             'pytest-cov==3.0.0;python_version>="3.6"',
         ],


### PR DESCRIPTION
## Add a Context Manager method for switching into iframes using a ``with`` statement
* [Add Context Manager frame_switch(frame). ("with" required)](https://github.com/seleniumbase/SeleniumBase/commit/1512f820682f043a3ef81db2afbaa787c825c0f9)
* This resolves https://github.com/seleniumbase/SeleniumBase/issues/1408
* Example usage: ``with self.frame_switch(frame):``

Here's an example test that demonstrates this feature:

```python
from seleniumbase import BaseCase

class FrameTests(BaseCase):
    def test_iframes_with_context_manager(self):
        self.open("https://seleniumbase.io/w3schools/iframes.html")
        with self.frame_switch("iframeResult"):
            self.assert_text("HTML Iframes", "h2")
            with self.frame_switch('[title*="Iframe"]'):
                self.assert_text("This page is displayed in an iframe", "h1")
            self.assert_text("Use CSS width & height to specify", "p")
            with self.frame_switch('[title*="Iframe"]'):
                self.assert_text("seleniumbase.io/w3schools/iframes", "a")
        self.click("button#runbtn")
        with self.frame_switch("iframeResult"):
            self.highlight('iframe[title="Iframe Example"]')
```