### PR TITLE
Fix intermittent issue with Firefox and geckodriver

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "3.5.7"
+__version__ = "3.5.8"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import sys
+import time
 import urllib3
 import warnings
 from selenium import webdriver
@@ -1518,17 +1519,21 @@ def get_local_driver(
                     )
                 except BaseException as e:
                     if (
-                        "Process unexpectedly closed" in str(e)
+                        "geckodriver unexpectedly exited" in str(e)
+                        or "Process unexpectedly closed" in str(e)
                         or "Failed to read marionette port" in str(e)
                         or "A connection attempt failed" in str(e)
                         or hasattr(e, "msg") and (
-                            "Process unexpectedly closed" in e.msg
+                            "geckodriver unexpectedly exited" in e.msg
+                            or "Process unexpectedly closed" in e.msg
                             or "Failed to read marionette port" in e.msg
                             or "A connection attempt failed" in e.msg
                         )
                     ):
-                        # Firefox probably just auto-updated itself.
+                        # Firefox probably just auto-updated itself,
+                        # which causes intermittent issues to occur.
                         # Trying again right after that often works.
+                        time.sleep(0.1)
                         return webdriver.Firefox(
                             service=service,
                             options=firefox_options,
@@ -1550,17 +1555,21 @@ def get_local_driver(
                     )
                 except BaseException as e:
                     if (
-                        "Process unexpectedly closed" in str(e)
+                        "geckodriver unexpectedly exited" in str(e)
+                        or "Process unexpectedly closed" in str(e)
                         or "Failed to read marionette port" in str(e)
                         or "A connection attempt failed" in str(e)
                         or hasattr(e, "msg") and (
-                            "Process unexpectedly closed" in e.msg
+                            "geckodriver unexpectedly exited" in e.msg
+                            or "Process unexpectedly closed" in e.msg
                             or "Failed to read marionette port" in e.msg
                             or "A connection attempt failed" in e.msg
                         )
                     ):
-                        # Firefox probably just auto-updated itself.
+                        # Firefox probably just auto-updated itself,
+                        # which causes intermittent issues to occur.
                         # Trying again right after that often works.
+                        time.sleep(0.1)
                         return webdriver.Firefox(
                             service=service,
                             options=firefox_options,


### PR DESCRIPTION
## Fix intermittent issue with Firefox and geckodriver

* [Fix intermittent Firefox issue](https://github.com/seleniumbase/SeleniumBase/commit/c7addc1cf9c1b198e84d2c3df64480bf7e618217)
* This resolves https://github.com/seleniumbase/SeleniumBase/issues/1424

The following intermittent issues should all be handled now:

```
"geckodriver unexpectedly exited"
"Process unexpectedly closed"
"Failed to read marionette port"
"A connection attempt failed"
```

(For situations caused intermittently by the Firefox auto-update process that checks to see if an update is available, whether to perform the update, and then perform the update if applicable.)