### PR TITLE
Handle extension capabilities

### DIFF
--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -1068,6 +1068,7 @@ def get_remote_driver(
         screen_resolution = None
         browser_version = None
         platform_name = None
+        custom_caps = {}
         for key in desired_caps.keys():
             capabilities[key] = desired_caps[key]
             if key == "selenoid:options":
@@ -1079,6 +1080,8 @@ def get_remote_driver(
                 browser_version = desired_caps[key]
             elif key == "platform" or key == "platformName":
                 platform_name = desired_caps[key]
+            elif re.match("[a-zA-Z0-9]*:[a-zA-Z0-9]*", key):
+                custom_caps[key] = desired_caps[key]
         if selenium4:
             chrome_options.set_capability("cloud:options", capabilities)
             if selenoid:
@@ -1093,6 +1096,9 @@ def get_remote_driver(
             if platform_name:
                 plat_name = platform_name
                 chrome_options.set_capability("platformName", plat_name)
+            if custom_caps:
+                for key in custom_caps:
+                    chrome_options.set_capability(key, custom_caps[key])
             return webdriver.Remote(
                 command_executor=address,
                 options=chrome_options,
@@ -1133,6 +1139,7 @@ def get_remote_driver(
         screen_resolution = None
         browser_version = None
         platform_name = None
+        custom_caps = {}
         for key in desired_caps.keys():
             capabilities[key] = desired_caps[key]
             if key == "selenoid:options":
@@ -1144,6 +1151,8 @@ def get_remote_driver(
                 browser_version = desired_caps[key]
             elif key == "platform" or key == "platformName":
                 platform_name = desired_caps[key]
+            elif re.match("[a-zA-Z0-9]*:[a-zA-Z0-9]*", key):
+                custom_caps[key] = desired_caps[key]
         if selenium4:
             firefox_options.set_capability("cloud:options", capabilities)
             if selenoid:
@@ -1158,6 +1167,9 @@ def get_remote_driver(
             if platform_name:
                 plat_name = platform_name
                 firefox_options.set_capability("platformName", plat_name)
+            if custom_caps:
+                for key in custom_caps:
+                    firefox_options.set_capability(key, custom_caps[key])
             return webdriver.Remote(
                 command_executor=address,
                 options=firefox_options,
@@ -1278,6 +1290,7 @@ def get_remote_driver(
         screen_resolution = None
         browser_version = None
         platform_name = None
+        custom_caps = {}
         for key in desired_caps.keys():
             capabilities[key] = desired_caps[key]
             if key == "selenoid:options":
@@ -1289,6 +1302,8 @@ def get_remote_driver(
                 browser_version = desired_caps[key]
             elif key == "platform" or key == "platformName":
                 platform_name = desired_caps[key]
+            elif re.match("[a-zA-Z0-9]*:[a-zA-Z0-9]*", key):
+                custom_caps[key] = desired_caps[key]
         if selenium4:
             opera_options.set_capability("cloud:options", capabilities)
             if selenoid:
@@ -1303,6 +1318,9 @@ def get_remote_driver(
             if platform_name:
                 plat_name = platform_name
                 opera_options.set_capability("platformName", plat_name)
+            if custom_caps:
+                for key in custom_caps:
+                    opera_options.set_capability(key, custom_caps[key])
             return webdriver.Remote(
                 command_executor=address,
                 options=opera_options,

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -1068,7 +1068,7 @@ def get_remote_driver(
         screen_resolution = None
         browser_version = None
         platform_name = None
-        custom_caps = {}
+        extension_capabilities = {}
         for key in desired_caps.keys():
             capabilities[key] = desired_caps[key]
             if key == "selenoid:options":
@@ -1081,7 +1081,7 @@ def get_remote_driver(
             elif key == "platform" or key == "platformName":
                 platform_name = desired_caps[key]
             elif re.match("[a-zA-Z0-9]*:[a-zA-Z0-9]*", key):
-                custom_caps[key] = desired_caps[key]
+                extension_capabilities[key] = desired_caps[key]
         if selenium4:
             chrome_options.set_capability("cloud:options", capabilities)
             if selenoid:
@@ -1096,9 +1096,10 @@ def get_remote_driver(
             if platform_name:
                 plat_name = platform_name
                 chrome_options.set_capability("platformName", plat_name)
-            if custom_caps:
-                for key in custom_caps:
-                    chrome_options.set_capability(key, custom_caps[key])
+            if extension_capabilities:
+                for key in extension_capabilities:
+                    ext_caps = extension_capabilities
+                    chrome_options.set_capability(key, ext_caps[key])
             return webdriver.Remote(
                 command_executor=address,
                 options=chrome_options,
@@ -1139,7 +1140,7 @@ def get_remote_driver(
         screen_resolution = None
         browser_version = None
         platform_name = None
-        custom_caps = {}
+        extension_capabilities = {}
         for key in desired_caps.keys():
             capabilities[key] = desired_caps[key]
             if key == "selenoid:options":
@@ -1152,7 +1153,7 @@ def get_remote_driver(
             elif key == "platform" or key == "platformName":
                 platform_name = desired_caps[key]
             elif re.match("[a-zA-Z0-9]*:[a-zA-Z0-9]*", key):
-                custom_caps[key] = desired_caps[key]
+                extension_capabilities[key] = desired_caps[key]
         if selenium4:
             firefox_options.set_capability("cloud:options", capabilities)
             if selenoid:
@@ -1167,9 +1168,10 @@ def get_remote_driver(
             if platform_name:
                 plat_name = platform_name
                 firefox_options.set_capability("platformName", plat_name)
-            if custom_caps:
-                for key in custom_caps:
-                    firefox_options.set_capability(key, custom_caps[key])
+            if extension_capabilities:
+                for key in extension_capabilities:
+                    ext_caps = extension_capabilities
+                    firefox_options.set_capability(key, ext_caps[key])
             return webdriver.Remote(
                 command_executor=address,
                 options=firefox_options,
@@ -1290,7 +1292,7 @@ def get_remote_driver(
         screen_resolution = None
         browser_version = None
         platform_name = None
-        custom_caps = {}
+        extension_capabilities = {}
         for key in desired_caps.keys():
             capabilities[key] = desired_caps[key]
             if key == "selenoid:options":
@@ -1303,7 +1305,7 @@ def get_remote_driver(
             elif key == "platform" or key == "platformName":
                 platform_name = desired_caps[key]
             elif re.match("[a-zA-Z0-9]*:[a-zA-Z0-9]*", key):
-                custom_caps[key] = desired_caps[key]
+                extension_capabilities[key] = desired_caps[key]
         if selenium4:
             opera_options.set_capability("cloud:options", capabilities)
             if selenoid:
@@ -1318,9 +1320,10 @@ def get_remote_driver(
             if platform_name:
                 plat_name = platform_name
                 opera_options.set_capability("platformName", plat_name)
-            if custom_caps:
-                for key in custom_caps:
-                    opera_options.set_capability(key, custom_caps[key])
+            if extension_capabilities:
+                for key in extension_capabilities:
+                    ext_caps = extension_capabilities
+                    opera_options.set_capability(key, ext_caps[key])
             return webdriver.Remote(
                 command_executor=address,
                 options=opera_options,


### PR DESCRIPTION
Handle extension capabilities in the desired capabilities flow. These are formatted as string:string, and is the pattern for passing extra vendor specific capabilities. See https://www.w3.org/TR/webdriver1/#dfn-extension-capability