### PR TITLE
Convert numbers to strings before performing text asserts

### DIFF
--- a/examples/test_usefixtures.py
+++ b/examples/test_usefixtures.py
@@ -5,11 +5,14 @@ import pytest
 class Test_UseFixtures:
     def test_usefixtures_on_class(self):
         sb = self.sb
-        sb.open("https://google.com/ncr")
-        sb.type('input[title="Search"]', "SeleniumBase GitHub\n")
-        sb.click('a[href*="github.com/seleniumbase/SeleniumBase"]')
-        sb.assert_text("SeleniumBase", 'strong[itemprop="name"]')
-        sb.assert_text("integrations")
-        sb.assert_element('a[title="help_docs"]')
-        sb.click('a[title="examples"]')
-        sb.assert_exact_text("examples", "strong.final-path")
+        sb.open("https://seleniumbase.io/realworld/login")
+        sb.type("#username", "demo_user")
+        sb.type("#password", "secret_pass")
+        sb.enter_mfa_code("#totpcode", "GAXG2MTEOR3DMMDG")  # 6-digit
+        sb.assert_text("Welcome!", "h1")
+        sb.highlight("img#image1")  # A fancier assert_element() call
+        sb.click('a:contains("This Page")')
+        sb.save_screenshot_to_logs()  # In "./latest_logs/" folder.
+        sb.click_link("Sign out")  # Must be "a" tag. Not "button".
+        sb.assert_element('a:contains("Sign in")')
+        sb.assert_exact_text("You have been signed out!", "#top_message")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ packaging>=20.9;python_version<"3.6"
 packaging>=21.3;python_version>="3.6"
 setuptools>=44.1.1;python_version<"3.6"
 setuptools>=59.6.0;python_version>="3.6" and python_version<"3.7"
-setuptools>=65.2.0;python_version>="3.7"
+setuptools>=65.3.0;python_version>="3.7"
 tomli>=1.2.3;python_version>="3.6" and python_version<"3.7"
 tomli>=2.0.1;python_version>="3.7"
 wheel>=0.37.1

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.1.0"
+__version__ = "4.1.1"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -7103,6 +7103,7 @@ class BaseCase(unittest.TestCase):
         return element.get_attribute(attribute)
 
     def __wait_for_shadow_text_visible(self, text, selector, timeout):
+        text = str(text)
         start_ms = time.time() * 1000.0
         stop_ms = start_ms + (settings.SMALL_TIMEOUT * 1000.0)
         for x in range(int(settings.SMALL_TIMEOUT * 10)):
@@ -7136,6 +7137,7 @@ class BaseCase(unittest.TestCase):
         return True
 
     def __wait_for_exact_shadow_text_visible(self, text, selector, timeout):
+        text = str(text)
         start_ms = time.time() * 1000.0
         stop_ms = start_ms + (settings.SMALL_TIMEOUT * 1000.0)
         for x in range(int(settings.SMALL_TIMEOUT * 10)):
@@ -7256,6 +7258,7 @@ class BaseCase(unittest.TestCase):
             return False
 
     def __is_shadow_text_visible(self, text, selector):
+        text = str(text)
         try:
             element = self.__get_shadow_element(selector, timeout=0.1)
             if self.browser == "safari":

--- a/seleniumbase/fixtures/page_actions.py
+++ b/seleniumbase/fixtures/page_actions.py
@@ -123,6 +123,7 @@ def is_text_visible(driver, text, selector, by="css selector", browser=None):
     @Returns
     Boolean (is text visible)
     """
+    text = str(text)
     try:
         element = driver.find_element(by=by, value=selector)
         element_text = element.text
@@ -467,6 +468,7 @@ def wait_for_text_visible(
     element = None
     is_present = False
     full_text = None
+    text = str(text)
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
@@ -571,6 +573,7 @@ def wait_for_exact_text_visible(
     element = None
     is_present = False
     actual_text = None
+    text = str(text)
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):
@@ -959,6 +962,7 @@ def wait_for_text_not_visible(
     @Returns
     A web element object that contains the text searched for
     """
+    text = str(text)
     start_ms = time.time() * 1000.0
     stop_ms = start_ms + (timeout * 1000.0)
     for x in range(int(timeout * 10)):

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
         'packaging>=21.3;python_version>="3.6"',
         'setuptools>=44.1.1;python_version<"3.6"',
         'setuptools>=59.6.0;python_version>="3.6" and python_version<"3.7"',
-        'setuptools>=65.2.0;python_version>="3.7"',
+        'setuptools>=65.3.0;python_version>="3.7"',
         'tomli>=1.2.3;python_version>="3.6" and python_version<"3.7"',
         'tomli>=2.0.1;python_version>="3.7"',
         "wheel>=0.37.1",


### PR DESCRIPTION
## Convert numbers to strings before performing text asserts

* Convert text args to strings before performing text asserts.
--> https://github.com/seleniumbase/SeleniumBase/commit/f512989b9958ce8f9d5f5dfd204a670dae72f705
--> This resolves https://github.com/seleniumbase/SeleniumBase/issues/1474
* Refresh Python dependencies.
--> https://github.com/seleniumbase/SeleniumBase/commit/5e948cb563cd7a61c951afcd5617e4dae4377d56