### PR TITLE
Refactoring options ordering

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.3.7"
+__version__ = "4.3.8"


### PR DESCRIPTION
## Refactoring options ordering

* Proxy authentication takes priority over headless Chromium mode. Since Proxy authentication requires the use of a chromium extension, and since headless Chromium does not support extensions, we have to pick one option over the other if both options are set.

Eg: ``pytest --headless --proxy=user:pass@server:port`` (Then headless mode is skipped)

* Headless Mode is prioritized over Undetected Chromedriver Mode.

Eg. ``pytest --headless --uc`` (Then undetected mode is skipped)

* If the user sets Headless Mode AND Proxy Auth AND Undetected Mode, then Proxy Auth AND Undetected Mode win out while Headless Mode is skipped in that specific situation.

Eg: ``pytest --headless --uc --proxy=user:pass@server:port`` (Then headless mode is skipped)