### PR TITLE
Refactor reports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ toml==0.10.2
 typing-extensions==3.10.0.2;python_version<"3.6"
 typing-extensions==4.1.1;python_version>="3.6" and python_version<"3.7"
 typing-extensions==4.2.0;python_version>="3.7" and python_version<"3.9"
-rich==12.5.1;python_version>="3.6" and python_version<"4.0"
+rich==12.6.0;python_version>="3.6" and python_version<"4.0"
 
 # --- Testing Requirements --- #
 # ("pip install -r requirements.txt" also installs this, but "pip install -e ." won't.)

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.5.2"
+__version__ = "4.5.3"

--- a/seleniumbase/core/log_helper.py
+++ b/seleniumbase/core/log_helper.py
@@ -116,11 +116,7 @@ def log_test_failure_data(test, test_logpath, driver, browser, url=None):
         pass
     try:
         duration = "%.2f" % (time.time() - (sb_config.start_time_ms / 1000.0))
-        d_len = len(str(duration))
-        s_len = 12 - d_len
-        if s_len < 2:
-            s_len = 2
-        duration = "%s%s(seconds)" % (duration, s_len * " ")
+        duration = "%ss" % duration
     except Exception:
         duration = "(Unknown Duration)"
     if browser_version:
@@ -129,10 +125,13 @@ def log_test_failure_data(test, test_logpath, driver, browser, url=None):
             headless = " / headless"
         if test.headless2 and browser in ["chrome", "edge"]:
             headless = " / headless2"
-        browser_displayed = "%s (%s%s)" % (browser, browser_version, headless)
+        if browser and len(browser) > 1:
+            # Capitalize the first letter
+            browser = "%s%s" % (browser[0].upper(), browser[1:])
+        browser_displayed = "%s %s%s" % (browser, browser_version, headless)
         if driver_name and driver_version:
-            driver_displayed = "%s (%s)" % (driver_name, driver_version)
-    if not browser_version:
+            driver_displayed = "%s %s" % (driver_name, driver_version)
+    else:
         browser_displayed = browser
         driver_displayed = "(Unknown Driver)"
     if not driver_displayed:
@@ -152,10 +151,10 @@ def log_test_failure_data(test, test_logpath, driver, browser, url=None):
         "--------------------------------------------------------------------"
     )
     data_to_save.append("Last Page: %s" % last_page)
+    data_to_save.append(" Duration: %s" % duration)
     data_to_save.append("  Browser: %s" % browser_displayed)
     data_to_save.append("   Driver: %s" % driver_displayed)
     data_to_save.append("Timestamp: %s" % timestamp)
-    data_to_save.append(" Duration: %s" % duration)
     data_to_save.append("     Date: %s" % the_date)
     data_to_save.append("     Time: %s" % the_time)
     data_to_save.append(
@@ -181,10 +180,11 @@ def log_test_failure_data(test, test_logpath, driver, browser, url=None):
         if hasattr(test, "is_nosetest") and test.is_nosetest:
             # Also save the data for the report
             sb_config._report_test_id = test_id
+            sb_config._report_fail_page = last_page
+            sb_config._report_duration = duration
             sb_config._report_browser = browser_displayed
             sb_config._report_driver = driver_displayed
             sb_config._report_timestamp = timestamp
-            sb_config._report_duration = duration
             sb_config._report_date = the_date
             sb_config._report_time = the_time
             sb_config._report_traceback = traceback_message
@@ -258,10 +258,15 @@ def log_skipped_test_data(test, test_logpath, driver, browser, reason):
         headless = ""
         if test.headless and browser in ["chrome", "edge", "firefox"]:
             headless = " / headless"
-        browser_displayed = "%s (%s%s)" % (browser, browser_version, headless)
+        if test.headless2 and browser in ["chrome", "edge"]:
+            headless = " / headless2"
+        if browser and len(browser) > 1:
+            # Capitalize the first letter
+            browser = "%s%s" % (browser[0].upper(), browser[1:])
+        browser_displayed = "%s %s%s" % (browser, browser_version, headless)
         if driver_name and driver_version:
-            driver_displayed = "%s (%s)" % (driver_name, driver_version)
-    if not browser_version:
+            driver_displayed = "%s %s" % (driver_name, driver_version)
+    else:
         browser_displayed = browser
         driver_displayed = "(Unknown Driver)"
     if not driver_displayed:

--- a/seleniumbase/core/report_helper.py
+++ b/seleniumbase/core/report_helper.py
@@ -54,11 +54,11 @@ def save_test_failure_data(name, folder=None):
     data_to_save.append(
         "--------------------------------------------------------------------"
     )
-    data_to_save.append("Last Page: %s" % sb_config._fail_page)
+    data_to_save.append("Last Page: %s" % sb_config._report_fail_page)
+    data_to_save.append(" Duration: %s" % sb_config._report_duration)
     data_to_save.append("  Browser: %s" % sb_config._report_browser)
     data_to_save.append("   Driver: %s" % sb_config._report_driver)
     data_to_save.append("Timestamp: %s" % sb_config._report_timestamp)
-    data_to_save.append(" Duration: %s" % sb_config._report_duration)
     data_to_save.append("     Date: %s" % sb_config._report_date)
     data_to_save.append("     Time: %s" % sb_config._report_time)
     data_to_save.append(

--- a/setup.py
+++ b/setup.py
@@ -243,7 +243,7 @@ setup(
         'typing-extensions==3.10.0.2;python_version<"3.6"',  # <3.9 for "rich"
         'typing-extensions==4.1.1;python_version>="3.6" and python_version<"3.7"',  # noqa: E501
         'typing-extensions==4.2.0;python_version>="3.7" and python_version<"3.9"',  # noqa: E501
-        'rich==12.5.1;python_version>="3.6" and python_version<"4.0"',
+        'rich==12.6.0;python_version>="3.6" and python_version<"4.0"',
     ],
     extras_require={
         # pip install -e .[coverage]


### PR DESCRIPTION
## Refactor reports
* Refactor reports
--> (See below for an example in the new format)
* Refresh Python dependencies
--> ``rich==12.6.0``

--------

Here's an example of a ``basic_test_info.txt`` report in the new format:

```
test_fail.py::FailingTests::test_find_army_of_robots_on_xkcd_desert_island
--------------------------------------------------------------------
Last Page: https://xkcd.com/731/
 Duration: 1.59s
  Browser: Chrome 105.0.5195.125 / headless
   Driver: chromedriver 105.0.5195.52
Timestamp: 1664724374  (Unix Timestamp)
     Date: Sunday, October 2, 2022
     Time: 11:26:14 AM  (EDT, UTC-05:00)
--------------------------------------------------------------------
Traceback: File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/unittest/case.py", line 591, in run
    self._callTestMethod(testMethod)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/Users/michael/github/SeleniumBase/examples/test_fail.py", line 16, in test_find_army_of_robots_on_xkcd_desert_island
    self.assert_element("div#ARMY_OF_ROBOTS", timeout=1)
  File "/Users/michael/github/SeleniumBase/seleniumbase/fixtures/base_case.py", line 10414, in assert_element
    self.wait_for_element_visible(selector, by=by, timeout=timeout)
  File "/Users/michael/github/SeleniumBase/seleniumbase/fixtures/base_case.py", line 7786, in wait_for_element_visible
    return page_actions.wait_for_element_visible(
  File "/Users/michael/github/SeleniumBase/seleniumbase/fixtures/page_actions.py", line 420, in wait_for_element_visible
    timeout_exception(NoSuchElementException, message)
  File "/Users/michael/github/SeleniumBase/seleniumbase/fixtures/page_actions.py", line 189, in timeout_exception
    raise exc(msg)
Exception: Message: 
 Element {div#ARMY_OF_ROBOTS} was not present after 1 second!
```