### PR TITLE
feat: add github workflow for docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,20 +23,20 @@ jobs:
         name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 
-      -
-        name: Build Docker Test Image
-        uses: docker/build-push-action@v3
-        id: build
-        with:
-          context: .
-          load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      -
-        name: Test Docker Image
-        run: |
-          docker run --rm -i ${{ steps.build.outputs.imageid }}
+#      -
+#        name: Build Docker Test Image
+#        uses: docker/build-push-action@v3
+#        id: build
+#        with:
+#          context: .
+#          load: true
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max
+#
+#      -
+#        name: Test Docker Image
+#        run: |
+#          docker run --rm -i ${{ steps.build.outputs.imageid }}
 
       - name: Get Docker Image Metadata
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/bukforks/seleniumbase
+            ghcr.io/seleniumbase/seleniumbase
           tags: |
             type=schedule
             type=semver,pattern={{version}}
@@ -89,7 +89,7 @@ jobs:
             ${{ steps.meta.outputs.labels }}
           cache-from: |
             type=gha
-            type=registry,ref=ghcr.io/bukforks/seleniumbase
+            type=registry,ref=ghcr.io/seleniumbase/seleniumbase
           cache-to: |
             type=gha,mode=max
           platforms: linux/amd64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,4 +92,4 @@ jobs:
             type=registry,ref=ghcr.io/bukforks/seleniumbase
           cache-to: |
             type=gha,mode=max
-          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/386,linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            bukforks/seleniumbase
+            ghcr.io/bukforks/seleniumbase
           tags: |
             type=schedule
             type=semver,pattern={{version}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,4 +92,4 @@ jobs:
             type=registry,ref=ghcr.io/bukforks/seleniumbase
           cache-to: |
             type=gha,mode=max
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,95 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+
+  Docker:
+    name: Build and Push Docker Images
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+
+      -
+        name: Set up Docker Build
+        uses: docker/setup-buildx-action@v2
+
+      -
+        name: Build Docker Test Image
+        uses: docker/build-push-action@v3
+        id: build
+        with:
+          context: .
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      -
+        name: Test Docker Image
+        run: |
+          docker run --rm -i ${{ steps.build.outputs.imageid }}
+
+      - name: Get Docker Image Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            bukforks/seleniumbase
+          tags: |
+            type=schedule
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v2
+
+#      - name: Login to Docker Hub Container Registry
+#        uses: docker/login-action@v2
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_ROBOT_TOKEN }}
+
+      - name: Login to GHCR.io Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+#      - name: Login to Quay.io Container Registry
+#        uses: docker/login-action@v2
+#        with:
+#          registry: quay.io
+#          username: ${{ secrets.QUAY_USERNAME }}
+#          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      -
+        # Push other images
+        name: Build and Push Docker Images
+        uses: docker/build-push-action@v3
+        id: build-all
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=gha
+            type=registry,ref=quay.io/k8start/http-headers
+          cache-to: |
+            type=gha,mode=max
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,7 +89,7 @@ jobs:
             ${{ steps.meta.outputs.labels }}
           cache-from: |
             type=gha
-            type=registry,ref=quay.io/k8start/http-headers
+            type=registry,ref=ghcr.io/bukforks/seleniumbase
           cache-to: |
             type=gha,mode=max
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,4 +92,4 @@ jobs:
             type=registry,ref=ghcr.io/bukforks/seleniumbase
           cache-to: |
             type=gha,mode=max
-          platforms: linux/386,linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,4 +92,4 @@ jobs:
             type=registry,ref=ghcr.io/bukforks/seleniumbase
           cache-to: |
             type=gha,mode=max
-          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x


### PR DESCRIPTION
Hey this is github workflow for building docker images. Here is example for ghcr: https://github.com/bukforks/SeleniumBase/pkgs/container/seleniumbase

I left some sections commented out because maybe you want to push into docker hub registry then you would need to add this login section and image here: 
````
      - name: Get Docker Image Metadata
        id: meta
        uses: docker/metadata-action@v4
        with:
          images: |
            ghcr.io/seleniumbase/seleniumbase
            seleniumbase/seleniumbase <<<<<<<<

 ````