### PR TITLE
Headless and env settings

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.9.10"
+__version__ = "4.9.11"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -2342,7 +2342,6 @@ def get_local_driver(
                 device_height,
                 device_pixel_ratio,
             )
-            opera_options.headless = False  # No support for headless Opera
             warnings.simplefilter("ignore", category=DeprecationWarning)
             return webdriver.Opera(options=opera_options)
         except Exception:
@@ -2626,7 +2625,6 @@ def get_local_driver(
                                 from urllib.error import URLError
 
                                 if "linux" in PLATFORM:
-                                    chrome_options.headless = False  # Use Xvfb
                                     if "--headless" in (
                                         chrome_options.arguments
                                     ):
@@ -2919,7 +2917,8 @@ def get_local_driver(
                         " headless mode. Attempting to use the"
                         " SeleniumBase virtual display on Linux..."
                     )
-                    chrome_options.headless = False
+                    if "--headless" in chrome_options.arguments:
+                        chrome_options.arguments.remove("--headless")
                     return webdriver.Chrome(options=chrome_options)
         except Exception:
             try:

--- a/seleniumbase/plugins/base_plugin.py
+++ b/seleniumbase/plugins/base_plugin.py
@@ -62,6 +62,7 @@ class Base(Plugin):
                 constants.Environment.BETA,
                 constants.Environment.MAIN,
                 constants.Environment.TEST,
+                constants.Environment.UAT,
             ),
             default=constants.Environment.TEST,
             help="""This option sets a test env from a list of choices.

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -210,6 +210,7 @@ def pytest_addoption(parser):
             constants.Environment.BETA,
             constants.Environment.MAIN,
             constants.Environment.TEST,
+            constants.Environment.UAT,
         ),
         default=constants.Environment.TEST,
         help="""This option sets a test env from a list of choices.


### PR DESCRIPTION
### Headless and ``--env`` settings
* When setting headless mode, don't use options.headless
--> https://github.com/seleniumbase/SeleniumBase/commit/63306d83923749e20f2dd22b3ef3332e26246d5e
--> This resolves https://github.com/seleniumbase/SeleniumBase/issues/1638
* Add ``--env=uat`` (User Acceptance Testing)
--> https://github.com/seleniumbase/SeleniumBase/commit/f48da77f87ab28f905bf86a2de93171ff23482ee
--> This completes changes from version ``4.9.10``