### PR TITLE
Refine UC Mode and update pytest-xdist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ pytest-ordering==0.6
 pytest-rerunfailures==10.3;python_version<"3.7"
 pytest-rerunfailures==11.1.2;python_version>="3.7"
 pytest-xdist==2.5.0;python_version<"3.7"
-pytest-xdist==3.2.0;python_version>="3.7"
+pytest-xdist==3.2.1;python_version>="3.7"
 parameterized==0.8.1
 sbvirtualdisplay==1.2.0
 behave==1.2.6

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.13.12"
+__version__ = "4.13.13"

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -2667,10 +2667,7 @@ class BaseCase(unittest.TestCase):
             try:
                 href = element.get_attribute("href")
                 target = element.get_attribute("target")
-                if len(href) > 0 and target == "_blank":
-                    self.driver.tab_new(href)
-                    self.switch_to_window(-1)
-                elif len(href) > 0:
+                if len(href) > 0 and target != "_blank":
                     element.uc_click()
                 else:
                     element.click()
@@ -3407,12 +3404,6 @@ class BaseCase(unittest.TestCase):
     def open_new_window(self, switch_to=True):
         """Opens a new browser tab/window and switches to it by default."""
         self.wait_for_ready_state_complete()
-        if hasattr(self.driver, "tab_new"):
-            self.driver.tab_new("about:blank")
-            if switch_to:
-                self.switch_to_window(-1)
-            time.sleep(0.01)
-            return
         if selenium4_or_newer and switch_to:
             self.driver.switch_to.new_window("tab")
         else:

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ setup(
         'pytest-rerunfailures==10.3;python_version<"3.7"',
         'pytest-rerunfailures==11.1.2;python_version>="3.7"',
         'pytest-xdist==2.5.0;python_version<"3.7"',
-        'pytest-xdist==3.2.0;python_version>="3.7"',
+        'pytest-xdist==3.2.1;python_version>="3.7"',
         "parameterized==0.8.1",
         "sbvirtualdisplay==1.2.0",
         "behave==1.2.6",


### PR DESCRIPTION
## Refine UC Mode and update pytest-xdist
* Make refinements to UC Mode (``--uc``)
--> https://github.com/seleniumbase/SeleniumBase/pull/1801/commits/1757ef27c2a2e0188be78f04470fb6eee42b1006
--> This resolves issues with tests that use multiple tabs in UC Mode
* Also refresh Python dependencies (``pytest-xdist``)
--> https://github.com/seleniumbase/SeleniumBase/pull/1801/commits/100f4738d9cc34f1f9ddfbedded79ee352012047
--> This resolves a ``pytest-xdist`` issue with using ``--dist=worksteal`` in multithreaded mode.
--> (Details: https://github.com/pytest-dev/pytest-xdist/issues/884)