### PR TITLE
Update minimum "filelock" version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ attrs>=22.2.0;python_version>="3.7"
 PyYAML>=6.0
 certifi>=2022.12.7
 filelock>=3.4.1;python_version<"3.7"
-filelock>=3.10.2;python_version>="3.7"
+filelock>=3.10.3;python_version>="3.7"
 platformdirs>=2.4.0;python_version<"3.7"
 platformdirs>=3.1.1;python_version>="3.7"
 pyparsing>=3.0.7;python_version<"3.7"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.13.17"
+__version__ = "4.13.18"

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ setup(
         "PyYAML>=6.0",
         "certifi>=2022.12.7",
         'filelock>=3.4.1;python_version<"3.7"',
-        'filelock>=3.10.2;python_version>="3.7"',
+        'filelock>=3.10.3;python_version>="3.7"',
         'platformdirs>=2.4.0;python_version<"3.7"',
         'platformdirs>=3.1.1;python_version>="3.7"',
         'pyparsing>=3.0.7;python_version<"3.7"',


### PR DESCRIPTION
## Update minimum "filelock" version
* Update minimum ``filelock`` version for a bug-fix
--> New minimum: ``filelock>=3.10.3``
--> https://github.com/seleniumbase/SeleniumBase/commit/d95f7c8a63e361a3cb9a2e82dad46fa3169a1235
