### PR TITLE
Fix driver download script

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.16.1"
+__version__ = "4.16.2"

--- a/seleniumbase/console_scripts/sb_install.py
+++ b/seleniumbase/console_scripts/sb_install.py
@@ -256,6 +256,8 @@ def main(override=None, intel_for_uc=None):
                 ).split(".")[0]
                 if int(major_chrome_version) < 72:
                     major_chrome_version = None
+                elif int(major_chrome_version) > 114:
+                    major_chrome_version = "114"
             except Exception:
                 major_chrome_version = None
             if major_chrome_version and major_chrome_version.isnumeric():


### PR DESCRIPTION
## Fix driver download script
* [Fix driver download script](https://github.com/seleniumbase/SeleniumBase/commit/72750da8b03f402220eff0fc77bae301607c3b45)
* This resolves https://github.com/seleniumbase/SeleniumBase/issues/1969

> As mentioned in https://github.com/seleniumbase/SeleniumBase/issues/1969, until the Chromium Team resolves https://bugs.chromium.org/p/chromium/issues/detail?id=1466427, it's best to set chromedriver 114 as the maximum version for download, (and to keep using it for Chrome 115+).