### PR TITLE
Fix log message on exception in UC Reactor

### DIFF
--- a/seleniumbase/undetected/reactor.py
+++ b/seleniumbase/undetected/reactor.py
@@ -81,4 +81,4 @@ class Reactor(threading.Thread):
                 if "invalid session id" in str(e):
                     pass
                 else:
-                    logging.debug("exception ignored :", e)
+                    logger.debug("exception ignored : %s", e)


### PR DESCRIPTION
This bug took me a while to find, but the main problem it had is that it caused all my logging messages to print with the root logger in the program I use seleniumbase in. I included some code below that will show you the issue.

```py
import logging
import logging.handlers
import time

from seleniumbase import Driver


logger = logging.getLogger("sub")
logger.setLevel(logging.DEBUG)

# Will not show up
logger.debug("debug")

driver = Driver(undetectable=True, uc_cdp_events=True)
driver.quit()

# Give time for the Reactor to stop
time.sleep(3)

# Without this fix, this message will show up even though the debug message before did not
logger.debug("Should not show up")
```