### PR TITLE
Add an additional valid Brave binary to Linux

### DIFF
--- a/seleniumbase/fixtures/constants.py
+++ b/seleniumbase/fixtures/constants.py
@@ -386,6 +386,7 @@ class ValidBinaries:
         "google-chrome-beta",
         "google-chrome-dev",
         "google-chrome-unstable",
+        "brave",
         "brave-browser",
         "brave-browser-stable",
         "opera",


### PR DESCRIPTION
This binary name is used by the package brave-bin, the recommended package to install on Arch Linux (https://brave.com/linux/#arch). This fix also allows people to not have to set up a symlink between `/usr/bin/brave` and `/usr/bin/brave-browser` when using Arch Linux.