### PR TITLE
Add a `"breakpoint"` option for reconnecting in UC Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,13 @@ class CoffeeCartTest(BaseCase):
     def test_coffee_cart(self):
         self.open("https://seleniumbase.io/coffee/")
         self.assert_title("Coffee Cart")
+        self.assert_element('button:contains("Total: $0.00")')
         self.click('div[data-sb="Cappuccino"]')
+        self.assert_exact_text("cart (1)", 'a[aria-label="Cart page"]')
         self.click('div[data-sb="Flat-White"]')
+        self.assert_exact_text("cart (2)", 'a[aria-label="Cart page"]')
         self.click('div[data-sb="Cafe-Latte"]')
+        self.assert_exact_text("cart (3)", 'a[aria-label="Cart page"]')
         self.click('a[aria-label="Cart page"]')
         self.assert_exact_text("Total: $53.00", "button.pay")
         self.click("button.pay")

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ rich==13.7.0
 
 coverage==6.2;python_version<"3.7"
 coverage==7.2.7;python_version>="3.7" and python_version<"3.8"
-coverage==7.3.3;python_version>="3.8"
+coverage==7.3.4;python_version>="3.8"
 pytest-cov==4.0.0;python_version<"3.7"
 pytest-cov==4.1.0;python_version>="3.7"
 flake8==5.0.4;python_version<"3.9"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.22.1"
+__version__ = "4.22.2"

--- a/seleniumbase/fixtures/constants.py
+++ b/seleniumbase/fixtures/constants.py
@@ -388,6 +388,7 @@ class ValidBinaries:
         "google-chrome-unstable",
         "brave-browser",
         "brave-browser-stable",
+        "brave",
         "opera",
         "opera-stable",
         "chrome.exe",  # WSL (Windows Subsystem for Linux)

--- a/seleniumbase/undetected/__init__.py
+++ b/seleniumbase/undetected/__init__.py
@@ -427,7 +427,12 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 self.service.stop()
             except Exception:
                 pass
-            time.sleep(timeout)
+            if isinstance(timeout, str):
+                if timeout.lower() == "breakpoint":
+                    breakpoint()  # To continue:
+                    pass  # Type "c" & press ENTER!
+            else:
+                time.sleep(timeout)
             try:
                 self.service.start()
             except Exception:

--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,7 @@ setup(
         # Usage: coverage run -m pytest; coverage html; coverage report
         "coverage": [
             'coverage==7.2.7;python_version<"3.8"',
-            'coverage==7.3.3;python_version>="3.8"',
+            'coverage==7.3.4;python_version>="3.8"',
             'pytest-cov==4.1.0',
         ],
         # pip install -e .[flake8]


### PR DESCRIPTION
## Add a `"breakpoint"` option for reconnecting in UC Mode

* [Add "breakpoint" option for reconnecting in UC Mode](https://github.com/seleniumbase/SeleniumBase/commit/bcf0fb565b58400526a35f53de3fc7bd972d662c)
--> This resolves https://github.com/seleniumbase/SeleniumBase/issues/2384

Other unrelated changes:

* [Add "brave" to valid Chromium binary_location filenames](https://github.com/seleniumbase/SeleniumBase/commit/a9a3156471841de8a0375385be2ddb9a369e722d)
* [Update coverage version in optional dependencies](https://github.com/seleniumbase/SeleniumBase/commit/6bfea20ab6e4f3fa60836e36c653b2447b2385ae)

--------

### More details:

Currently, some UC Mode methods let you set a custom `reconnect_time` / `timeout` (in seconds) to specify how long the driver should be disconnected from Chrome to prevent detection before reconnecting again. The new plan here is to add an option of `"breakpoint"` for that arg's value. Doing this should drop in a Python `breakpoint()` while the driver is disconnected from the browser. This will allow the user to perform manual actions (until typing `c` and pressing ENTER to continue from the breakpoint).

Here are those existing methods: (Use `self.driver` for `BaseCase` formats. Use `sb.driver` for `SB()` formats):

```python
driver.uc_open_with_reconnect(url, reconnect_time)
# Examples:
driver.uc_open_with_reconnect("https://nowsecure.nl/#relax", reconnect_time=5)
driver.uc_open_with_reconnect("https://nowsecure.nl/#relax", 5)

driver.reconnect(timeout)
# Examples:
driver.reconnect(5)
driver.reconnect(timeout=5)
```

With this change, you'll now be able to set the `reconnect_time` / `timeout` to `"breakpoint"` as a valid option.

Instead of waiting for a set time, the program will run a Python `breakpoint()` so that the user will be able to continue when ready (using `c` + ENTER):

Examples that should work once this ticket is completed:

```python
driver.uc_open_with_reconnect("https://nowsecure.nl/#relax", reconnect_time="breakpoint")
driver.uc_open_with_reconnect("https://nowsecure.nl/#relax", "breakpoint")

driver.reconnect(timeout="breakpoint")
driver.reconnect("breakpoint")
```
