### PR TITLE
Expand firefox_pref to allow URLs as VALUEs in KEY:VALUE pairs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip>=23.3.2
 packaging>=23.2
 setuptools>=68.0.0;python_version<"3.8"
-setuptools>=69.0.2;python_version>="3.8"
+setuptools>=69.0.3;python_version>="3.8"
 wheel>=0.42.0
 attrs>=23.1.0
 certifi>=2023.11.17

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.22.2"
+__version__ = "4.22.3"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -1270,7 +1270,10 @@ def _set_firefox_options(
                 f_pref = firefox_pref_item.split(":")[0]
                 f_pref_value = firefox_pref_item.split(":")[1]
                 needs_conversion = True
-            else:  # More than one ":" in the set. (Too many!)
+            elif firefox_pref_item.count("://") == 1:
+                f_pref = firefox_pref_item.split(":")[0]
+                f_pref_value = ":".join(firefox_pref_item.split(":")[1:])
+            else:  # More than one ":" in the set without a URL.
                 raise Exception(
                     'Incorrect formatting for Firefox "pref:value" set!'
                 )

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
         'pip>=23.3.2',
         'packaging>=23.2',
         'setuptools>=68.0.0;python_version<"3.8"',
-        'setuptools>=69.0.2;python_version>="3.8"',
+        'setuptools>=69.0.3;python_version>="3.8"',
         'wheel>=0.42.0',
         'attrs>=23.1.0',
         "certifi>=2023.11.17",


### PR DESCRIPTION
## Expand `firefox_pref` to allow URLs as VALUEs in `KEY:VALUE` pairs
* [Expand firefox_pref="KEY:VALUE" to allow URLs as VALUEs](https://github.com/seleniumbase/SeleniumBase/commit/c7914993e36e01a62f5879d4beae0463d0082782)
--> This resolves https://github.com/seleniumbase/SeleniumBase/issues/2386
--> This resolves https://github.com/seleniumbase/SeleniumBase/issues/2387
* Also: [Refresh Python dependencies](https://github.com/seleniumbase/SeleniumBase/commit/b1fa3c5523383670f013993bf0d794de85182316)