### PR TITLE
Update Allure report site

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,7 +920,7 @@ behave behave_bdd/features/ --junit -D rs -D headless
 
 <h3>🔵 Allure Reports:</h3>
 
-See: [https://docs.qameta.io/allure/](https://docs.qameta.io/allure/#_pytest)
+See: [https://allurereport.org/docs/pytest/](https://allurereport.org/docs/pytest/)
 
 SeleniumBase no longer includes ``allure-pytest`` as part of installed dependencies. If you want to use it, install it first:
 


### PR DESCRIPTION
Allure Report documentation is moved from https://docs.qameta.io/allure/ to https://allurereport.org/docs/. The suggested change updates the link.
