### PR TITLE
Enhance Compatibility Guide for macOS Users with Apple Silicon CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ Feature: SeleniumBase scenarios for the Simple App
 <h2><img src="https://seleniumbase.github.io/img/logo7.png" title="SeleniumBase" width="32" /> Install SeleniumBase:</h2>
 
 **You can install ``seleniumbase`` from [PyPI](https://pypi.org/project/seleniumbase/) or [GitHub](https://github.com/seleniumbase/SeleniumBase):**
+<h3>Special Instructions for macOS Users with Apple Silicon (M1/M2) CPUs</h3>
+If you're using a macOS machine with an Apple Silicon CPU (such as M1 or M2 chips) and you plan to use SeleniumBase's UC Mode, you might encounter an issue where the browser driver downloaded for UC Mode does not match your CPU architecture. This is because the driver meant for Intel CPUs is downloaded by default, which will not work directly on Apple Silicon CPUs.
+
+To resolve this issue, you need to install Rosetta, which allows applications compiled for Intel processors to run on Apple Silicon.
+
+Run the following command in your terminal to install Rosetta:
 
 🔵 **How to install ``seleniumbase`` from PyPI:**
 

--- a/help_docs/uc_mode.md
+++ b/help_docs/uc_mode.md
@@ -1,6 +1,15 @@
 <!-- SeleniumBase Docs -->
 
 ## [<img src="https://seleniumbase.github.io/img/logo6.png" title="SeleniumBase" width="32">](https://github.com/seleniumbase/SeleniumBase/) UC Mode 👤
+### Important Note for macOS Users with Apple Silicon (M1/M2) CPUs
+
+If you're using a macOS machine with an Apple Silicon CPU (such as M1 or M2 chips) and encountering issues with UC Mode saying "bad CPU type", it's because the downloaded chromedriver that SeleniumBase patches is intended for Intel processors. To solve this, you need to install Rosetta, which allows you to run applications compiled for Intel processors on Apple Silicon.
+
+Run the following command in your terminal to install Rosetta:
+
+```bash
+softwareupdate --install-rosetta
+```
 
 👤 SeleniumBase <b>UC Mode</b> (Undetected-Chromedriver Mode) allows bots to appear human, which lets them evade detection from anti-bot services that try to block them or trigger CAPTCHAs on various websites.
 


### PR DESCRIPTION
This pull request introduces an important update to the README and `uc_mode.md` documentation to address a compatibility issue faced by macOS users with Apple Silicon CPUs (M1/M2). The update provides clear instructions for installing Rosetta, enabling these users to successfully run SeleniumBase in UC Mode without encountering the "bad CPU type" error. 

By incorporating these instructions, I was aiming to improve the setup experience for a significant portion of the user base, ensuring that developers using the latest macOS hardware can leverage SeleniumBase's full capabilities without friction. This contribution underscores my commitment to supporting a diverse range of environments and configurations, facilitating wider adoption and user satisfaction.