### PR TITLE
update: get binary version of chrome in windows

### DIFF
--- a/seleniumbase/core/detect_b_ver.py
+++ b/seleniumbase/core/detect_b_ver.py
@@ -7,6 +7,8 @@ import re
 import subprocess
 import sys
 
+from seleniumbase.fixtures import shared_utils
+
 
 class File(object):
     def __init__(self, stream):
@@ -233,7 +235,10 @@ def get_browser_version_from_binary(binary_location):
     try:
         if binary_location.count(r"\ ") != binary_location.count(" "):
             binary_location = binary_location.replace(" ", r"\ ")
-        cmd_mapping = binary_location + " --version"
+        if shared_utils.is_windows():
+            binary_location = f'powershell -command "&{{(Get-Item {binary_location}).VersionInfo.ProductVersion}}"'
+        else:
+            cmd_mapping = binary_location + " --version"
         pattern = r"\d+\.\d+\.\d+"
         quad_pattern = r"\d+\.\d+\.\d+\.\d+"
         quad_version = read_version_from_cmd(cmd_mapping, quad_pattern)


### PR DESCRIPTION
adding a binary_location, the browser didn't get the version correctly in windows and a new browser window was popping up.
this fix should add a method to get the version correctly.

A request or a doubt:
Is it possible to give a chromedriver path while creating a driver obj?
self.browser = Driver(undetectable=True, user_data_dir=self.userDataDir, binary_location=constants.chromeBinaryPath, driver_version=117)
I have a project (educative.io_scraper) I already have a feature to download the chromedriver, so I wanted to know if there is any way to provide the path to chromedriver. After that it can be patched and the uc_driver could be saved in the same folder location?
