### PR TITLE
Add command-line shortcuts for `SB()` / `Driver()` formats

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.26.1"
+__version__ = "4.26.2"

--- a/seleniumbase/plugins/driver_manager.py
+++ b/seleniumbase/plugins/driver_manager.py
@@ -328,6 +328,12 @@ def Driver(
     ):
         recorder_mode = True
         recorder_ext = True
+    if headed is None:
+        # Override the default headless mode on Linux if set.
+        if "--gui" in sys_argv or "--headed" in sys_argv:
+            headed = True
+        else:
+            headed = False
     if (
         shared_utils.is_linux()
         and not headed
@@ -434,6 +440,13 @@ def Driver(
             disable_js = False
     if pls is not None and page_load_strategy is None:
         page_load_strategy = pls
+    if not page_load_strategy and "--pls=" in arg_join:
+        if "--pls=none" in sys_argv or '--pls="none"' in sys_argv:
+            page_load_strategy = "none"
+        elif "--pls=eager" in sys_argv or '--pls="eager"' in sys_argv:
+            page_load_strategy = "eager"
+        elif "--pls=normal" in sys_argv or '--pls="normal"' in sys_argv:
+            page_load_strategy = "normal"
     if page_load_strategy is not None:
         if page_load_strategy.lower() not in ["normal", "eager", "none"]:
             raise Exception(

--- a/seleniumbase/plugins/sb_manager.py
+++ b/seleniumbase/plugins/sb_manager.py
@@ -378,9 +378,20 @@ def SB(
             record_sleep = True
         else:
             record_sleep = False
+    if xvfb is None:
+        if "--xvfb" in sys_argv:
+            xvfb = True
+        else:
+            xvfb = False
     if not shared_utils.is_linux():
         # The Xvfb virtual display server is for Linux OS Only!
         xvfb = False
+    if headed is None:
+        # Override the default headless mode on Linux if set.
+        if "--gui" in sys_argv or "--headed" in sys_argv:
+            headed = True
+        else:
+            headed = False
     if (
         shared_utils.is_linux()
         and not headed
@@ -532,6 +543,13 @@ def SB(
         _disable_beforeunload = True
     if pls is not None and page_load_strategy is None:
         page_load_strategy = pls
+    if not page_load_strategy and "--pls=" in arg_join:
+        if "--pls=none" in sys_argv or '--pls="none"' in sys_argv:
+            page_load_strategy = "none"
+        elif "--pls=eager" in sys_argv or '--pls="eager"' in sys_argv:
+            page_load_strategy = "eager"
+        elif "--pls=normal" in sys_argv or '--pls="normal"' in sys_argv:
+            page_load_strategy = "normal"
     if page_load_strategy is not None:
         if page_load_strategy.lower() not in ["normal", "eager", "none"]:
             raise Exception(


### PR DESCRIPTION
## Add command-line shortcuts for `SB()` / `Driver()` formats
* [Add command-line shortcuts for SB() and Driver()](https://github.com/seleniumbase/SeleniumBase/commit/97d6b3a8ca2667645bbe5e85011ba59dbb22cd90)
--> This adds the following missing command-line shortcuts for `SB()` and `Driver()` formats:
------> `--gui` / `--headed`
------> `--xvfb` (for the `SB()` format only)
------> `--pls=none` (Page Load Strategy)
------> `--pls=eager` (Page Load Strategy)
------> `--pls=normal` (Page Load Strategy)