### PR TITLE
Update options and dependencies

### DIFF
--- a/mkdocs_build/requirements.txt
+++ b/mkdocs_build/requirements.txt
@@ -1,7 +1,7 @@
 # mkdocs dependencies for generating the seleniumbase.io website
 # Minimum Python version: 3.8 (for generating docs only)
 
-regex>=2024.5.15
+regex>=2024.7.24
 pymdown-extensions>=10.8.1
 pipdeptree>=2.23.1
 python-dateutil>=2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ pluggy==1.2.0;python_version<"3.8"
 pluggy==1.5.0;python_version>="3.8"
 py==1.11.0
 pytest==7.4.4;python_version<"3.8"
-pytest==8.3.1;python_version>="3.8"
+pytest==8.3.2;python_version>="3.8"
 pytest-html==2.0.1
 pytest-metadata==3.0.0;python_version<"3.8"
 pytest-metadata==3.1.1;python_version>="3.8"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.29.0"
+__version__ = "4.29.1"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -1659,6 +1659,7 @@ def _set_chrome_options(
     if user_agent:
         chrome_options.add_argument("--user-agent=%s" % user_agent)
     chrome_options.add_argument("--safebrowsing-disable-download-protection")
+    chrome_options.add_argument("--disable-search-engine-choice-screen")
     chrome_options.add_argument("--disable-browser-side-navigation")
     chrome_options.add_argument("--disable-save-password-bubble")
     chrome_options.add_argument("--disable-single-click-autofill")
@@ -3221,6 +3222,7 @@ def get_local_driver(
             "--disable-autofill-keyboard-accessory-view[8]"
         )
         edge_options.add_argument("--safebrowsing-disable-download-protection")
+        edge_options.add_argument("--disable-search-engine-choice-screen")
         edge_options.add_argument("--disable-browser-side-navigation")
         edge_options.add_argument("--disable-translate")
         if not enable_ws:

--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ setup(
         'pluggy==1.5.0;python_version>="3.8"',
         "py==1.11.0",  # Needed by pytest-html
         'pytest==7.4.4;python_version<"3.8"',
-        'pytest==8.3.1;python_version>="3.8"',
+        'pytest==8.3.2;python_version>="3.8"',
         "pytest-html==2.0.1",  # Newer ones had issues
         'pytest-metadata==3.0.0;python_version<"3.8"',
         'pytest-metadata==3.1.1;python_version>="3.8"',


### PR DESCRIPTION
## Update options and dependencies
* [Update default Chromium options](https://github.com/seleniumbase/SeleniumBase/commit/59e77ec53f5158aa86669f39326bccccefeac1e2)
--> This resolves https://github.com/seleniumbase/SeleniumBase/issues/2959
* [Refresh Python dependencies](https://github.com/seleniumbase/SeleniumBase/commit/e1006e44a5f85a5da45263b7648778c81ed84a8a)
--> Includes upgrading `pytest` (to `8.3.2`), which fixes an issue for Conda users.
--> (More info: https://github.com/pytest-dev/pytest/issues/12652)