### PR TITLE
Firefox options unnecessary prefix

### DIFF
--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -2450,6 +2450,10 @@ def _set_firefox_options(
             if not firefox_arg_item.startswith("--"):
                 if firefox_arg_item.startswith("-"):
                     firefox_arg_item = "-" + firefox_arg_item
+                elif firefox_arg_item.count(":\\") == 1 or firefox_arg_item.count(':/') == 1:
+                    firefox_arg_item = firefox_arg_item
+                else:
+                    firefox_arg_item = "--" + firefox_arg_item
             if len(firefox_arg_item) >= 3:
                 options.add_argument(firefox_arg_item)
     if firefox_pref:

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -2450,7 +2450,7 @@ def _set_firefox_options(
             if not firefox_arg_item.startswith("--"):
                 if firefox_arg_item.startswith("-"):
                     firefox_arg_item = "-" + firefox_arg_item
-                elif firefox_arg_item.count(":\\") == 1 or firefox_arg_item.count(':/') == 1:
+                elif firefox_arg_item.count(":\\") == 1 or firefox_arg_item.count(":/") == 1:
                     firefox_arg_item = firefox_arg_item
                 else:
                     firefox_arg_item = "--" + firefox_arg_item

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -2450,8 +2450,6 @@ def _set_firefox_options(
             if not firefox_arg_item.startswith("--"):
                 if firefox_arg_item.startswith("-"):
                     firefox_arg_item = "-" + firefox_arg_item
-                else:
-                    firefox_arg_item = "--" + firefox_arg_item
             if len(firefox_arg_item) >= 3:
                 options.add_argument(firefox_arg_item)
     if firefox_pref:


### PR DESCRIPTION
Hi, When adding arguments to specify the path to the firefox profile, you need to specify **-profile** and **path/to/profile** separated by commas, otherwise the profile does not open. I also tried **-profile=path/to/profile** and **--profile=path/to/profile**, but this does not open the profile, so the only option that works for firefox, I have this firefox_arg='-**profile,path/to/profile'**, but since in the same way, when checking firefox_arg_item, prefix '--' is added to the beginning of the path, which is why firefox cannot find the folder, the result is the string **'--path/to/profile'** because of this, I suggest checking that the string is the path and not adding prefix '--'