### PR TITLE
# Fix NoneType Error in `getActiveWindowTitle` Check

### DIFF
--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -1423,8 +1423,8 @@ def _uc_gui_handle_captcha_(driver, frame="iframe", ctype=None):
             IS_WINDOWS
             and hasattr(pyautogui, "getActiveWindowTitle")
         ):
-            
-            # if there is no-active window then it returns "None" which is not expected in the code. 
+            # Fix for NoneType error: When getActiveWindowTitle() returns None,
+            # default to empty string so startswith() check doesn't fail
             py_a_g_title = pyautogui.getActiveWindowTitle() or ""
             window_title = driver.get_title()
             if not py_a_g_title.startswith(window_title):

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -1423,7 +1423,9 @@ def _uc_gui_handle_captcha_(driver, frame="iframe", ctype=None):
             IS_WINDOWS
             and hasattr(pyautogui, "getActiveWindowTitle")
         ):
-            py_a_g_title = pyautogui.getActiveWindowTitle()
+            
+            # if there is no-active window then it returns "None" which is not expected in the code. 
+            py_a_g_title = pyautogui.getActiveWindowTitle() or ""
             window_title = driver.get_title()
             if not py_a_g_title.startswith(window_title):
                 window_rect = driver.get_window_rect()


### PR DESCRIPTION
# Fix NoneType Error in `getActiveWindowTitle` Check

## Problem
When running Selenium tests on Windows, we encountered an issue where `pyautogui.getActiveWindowTitle()` occasionally returns `None`. This causes the code to crash with a NoneType error because the subsequent `startswith()` method cannot be called on a `None` value.

This typically happens when:
- The window focus is temporarily lost
- The system is under heavy load
- Multiple windows are being managed simultaneously

## Solution
Added a fallback to empty string using Python's `or` operator:

```python
py_a_g_title = pyautogui.getActiveWindowTitle() or ""
```

This ensures that:
1. If `getActiveWindowTitle()` returns a valid title, it will be used
2. If it returns `None`, an empty string will be used instead
3. The `startswith()` check can safely proceed in all cases

The fix prevents test failures due to window management issues and improves stability of Selenium tests on Windows, with no impact on existing functionality when window titles are properly returned.

Verified the fix by running the test suite on Windows, specifically checking scenarios where window focus might be lost or changed rapidly.