### PR TITLE
Add shortcuts and error-handling

### DIFF
--- a/help_docs/customizing_test_runs.md
+++ b/help_docs/customizing_test_runs.md
@@ -337,6 +337,8 @@ pytest --headless -n8 --dashboard --html=report.html -v --rs --crumbs
 
 The above not only runs tests in parallel processes, but it also tells tests in the same process to share the same browser session, runs the tests in headless mode, displays the full name of each test on a separate line, creates a real-time dashboard of the test results, and creates a full report after all tests complete.
 
+--------
+
 🎛️ For extra speed, run your tests using `chrome-headless-shell`:
 
 First, get `chrome-headless-shell` if you don't already have it:
@@ -345,10 +347,10 @@ First, get `chrome-headless-shell` if you don't already have it:
 sbase get chs
 ```
 
-Then, run scripts with `binary_location` / `bl` set to `"chs"`:
+Then, run scripts with `--chs` / `chs=True`:
 
 ```bash
-pytest --bl="chs" -n8 --dashboard --html=report.html -v --rs
+pytest --chs -n8 --dashboard --html=report.html -v --rs
 ```
 
 That makes your tests run very quickly in headless mode.
@@ -483,6 +485,26 @@ The `PATH` in `--binary-location=PATH` / `--bl=PATH` can be:
 Before using the `"cft"` / `"chs"` options, call `sbase get cft` / `sbase get chs` in order to download the specified binaries into the `seleniumbase/drivers` folder. The default version is the latest stable version on https://googlechromelabs.github.io/chrome-for-testing/. You can change that by specifying the arg as a parameter. (Eg. `sbase get cft 131`, `sbase get chs 132`, etc.)
 
 With the `SB()` and `Driver()` formats, the binary location is set via the `binary_location` parameter.
+
+--------
+
+🎛️ To use the special `Chrome for Testing` binary:
+
+```bash
+sbase get cft
+```
+
+Then, run scripts with `--cft` / `cft=True`:
+
+```bash
+pytest --cft -n8 --dashboard --html=report.html -v --rs --headless
+```
+
+--------
+
+(Note that `--chs` / `chs=True` activates `Chrome-Headless-Shell`)
+
+`Chrome-Headless-Shell` is the fastest version of Chrome, designed specifically for headless automation. (This mode is NOT compatible with UC Mode!)
 
 --------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ packaging>=24.2
 setuptools~=70.2;python_version<"3.10"
 setuptools>=75.8.0;python_version>="3.10"
 wheel>=0.45.1
-attrs>=24.3.0
+attrs>=25.1.0
 certifi>=2024.12.14
 exceptiongroup>=1.2.2
 websockets~=13.1;python_version<"3.9"

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.34.2"
+__version__ = "4.34.3"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -2652,6 +2652,13 @@ def get_driver(
         headless2 = False  # Only for Chromium
         headless = True
     if (
+        is_using_uc(undetectable, browser_name)
+        and binary_location
+        and isinstance(binary_location, str)
+        and binary_location.lower() == "chs"
+    ):
+        raise Exception("UC Mode can't be used with Chrome-Headless-Shell!")
+    if (
         binary_location
         and isinstance(binary_location, str)
         and (

--- a/seleniumbase/plugins/driver_manager.py
+++ b/seleniumbase/plugins/driver_manager.py
@@ -137,6 +137,8 @@ def Driver(
     guest=None,  # Shortcut / Duplicate of "guest_mode".
     wire=None,  # Shortcut / Duplicate of "use_wire".
     pls=None,  # Shortcut / Duplicate of "page_load_strategy".
+    cft=None,  # Use "Chrome for Testing"
+    chs=None,  # Use "Chrome-Headless-Shell"
 ):
     """
     * SeleniumBase Driver as a Python Context Manager or a returnable object. *
@@ -550,6 +552,14 @@ def Driver(
             if arg.startswith("--bl="):
                 binary_location = arg.split("--bl=")[1]
                 break
+    if cft and not binary_location:
+        binary_location = "cft"
+    elif chs and not binary_location:
+        binary_location = "chs"
+    if "--cft" in sys_argv and not binary_location:
+        binary_location = "cft"
+    elif "--chs" in sys_argv and not binary_location:
+        binary_location = "chs"
     if (
         binary_location
         and binary_location.lower() == "chs"

--- a/seleniumbase/plugins/pytest_plugin.py
+++ b/seleniumbase/plugins/pytest_plugin.py
@@ -185,6 +185,20 @@ def pytest_addoption(parser):
         help="""Shortcut for --browser=safari""",
     )
     parser.addoption(
+        "--cft",
+        action="store_true",
+        dest="use_cft",
+        default=False,
+        help="""Shortcut for using `Chrome for Testing`""",
+    )
+    parser.addoption(
+        "--chs",
+        action="store_true",
+        dest="use_chs",
+        default=False,
+        help="""Shortcut for using `Chrome-Headless-Shell`""",
+    )
+    parser.addoption(
         "--with-selenium",
         action="store_true",
         dest="with_selenium",
@@ -1575,6 +1589,10 @@ def pytest_configure(config):
     sb_config.extension_dir = config.getoption("extension_dir")
     sb_config.disable_features = config.getoption("disable_features")
     sb_config.binary_location = config.getoption("binary_location")
+    if config.getoption("use_cft") and not sb_config.binary_location:
+        sb_config.binary_location = "cft"
+    elif config.getoption("use_chs") and not sb_config.binary_location:
+        sb_config.binary_location = "chs"
     if (
         sb_config.binary_location
         and sb_config.binary_location.lower() == "chs"

--- a/seleniumbase/plugins/sb_manager.py
+++ b/seleniumbase/plugins/sb_manager.py
@@ -119,6 +119,8 @@ def SB(
     pls=None,  # Shortcut / Duplicate of "page_load_strategy".
     sjw=None,  # Shortcut / Duplicate of "skip_js_waits".
     wfa=None,  # Shortcut / Duplicate of "wait_for_angularjs".
+    cft=None,  # Use "Chrome for Testing"
+    chs=None,  # Use "Chrome-Headless-Shell"
     save_screenshot=None,  # Save a screenshot at the end of each test.
     no_screenshot=None,  # No screenshots saved unless tests directly ask it.
     page_load_strategy=None,  # Set Chrome PLS to "normal", "eager", or "none".
@@ -588,6 +590,14 @@ def SB(
             if arg.startswith("--bl="):
                 binary_location = arg.split("--bl=")[1]
                 break
+    if cft and not binary_location:
+        binary_location = "cft"
+    elif chs and not binary_location:
+        binary_location = "chs"
+    if "--cft" in sys_argv and not binary_location:
+        binary_location = "cft"
+    elif "--chs" in sys_argv and not binary_location:
+        binary_location = "chs"
     if (
         binary_location
         and binary_location.lower() == "chs"

--- a/seleniumbase/plugins/selenium_plugin.py
+++ b/seleniumbase/plugins/selenium_plugin.py
@@ -145,6 +145,20 @@ class SeleniumBrowser(Plugin):
             help="""Shortcut for --browser=safari""",
         )
         parser.addoption(
+            "--cft",
+            action="store_true",
+            dest="use_cft",
+            default=False,
+            help="""Shortcut for using `Chrome for Testing`""",
+        )
+        parser.addoption(
+            "--chs",
+            action="store_true",
+            dest="use_chs",
+            default=False,
+            help="""Shortcut for using `Chrome-Headless-Shell`""",
+        )
+        parser.addoption(
             "--cap_file",
             "--cap-file",
             action="store",
@@ -1203,6 +1217,10 @@ class SeleniumBrowser(Plugin):
         test.test.extension_dir = self.options.extension_dir
         test.test.disable_features = self.options.disable_features
         test.test.binary_location = self.options.binary_location
+        if self.options.use_cft and not test.test.binary_location:
+            test.test.binary_location = "cft"
+        elif self.options.use_chs and not test.test.binary_location:
+            test.test.binary_location = "chs"
         if (
             test.test.binary_location
             and test.test.binary_location.lower() == "chs"

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup(
         'setuptools~=70.2;python_version<"3.10"',  # Newer ones had issues
         'setuptools>=75.8.0;python_version>="3.10"',
         'wheel>=0.45.1',
-        'attrs>=24.3.0',
+        'attrs>=25.1.0',
         "certifi>=2024.12.14",
         "exceptiongroup>=1.2.2",
         'websockets~=13.1;python_version<"3.9"',


### PR DESCRIPTION
## Add shortcuts and error-handling
* [Add shortcuts for using "Chrome for Testing" and "Chrome-Headless-Shell"](https://github.com/seleniumbase/SeleniumBase/commit/c167a23a06793319a84997f2e7b251b6334116b0)
--> `--cft` / `cft=True` ******** `--chs` / `chs=True`
* [Error early when combining UC Mode with Chrome-Headless-Shell](https://github.com/seleniumbase/SeleniumBase/commit/a6c0493a3ddccc798aa3a9549197514d2490d843)
--> You can't combine UC Mode with Chrome-Headless-Shell
--> Chrome-Headless-Shell is incredibly fast, but not stealthy
* [Refresh Python dependencies](https://github.com/seleniumbase/SeleniumBase/commit/02d13c66b44e66f83ab362c7d38b54af8d5ec9cc)