### PR TITLE
Compatibilty issues between CDP Mode and non default Chrome browser

### DIFF
--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -515,7 +515,7 @@ def uc_open_with_reconnect(driver, url, reconnect_time=None):
     return None
 
 
-def uc_open_with_cdp_mode(driver, url=None):
+def uc_open_with_cdp_mode(driver, url=None, browser_executable_path=None):
     import asyncio
     from seleniumbase.undetected.cdp_driver import cdp_util
 
@@ -562,6 +562,7 @@ def uc_open_with_cdp_mode(driver, url=None):
             headless=headless,
             headed=headed,
             xvfb=xvfb,
+            browser_executable_path=browser_executable_path
         )
     )
     loop.run_until_complete(driver.cdp_base.wait(0))

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -4870,7 +4870,7 @@ class BaseCase(unittest.TestCase):
         script = """document.designMode = 'off';"""
         self.execute_script(script)
 
-    def activate_cdp_mode(self, url=None):
+    def activate_cdp_mode(self, url=None, browser_executable_path=None):
         if hasattr(self.driver, "_is_using_uc") and self.driver._is_using_uc:
             if self.__is_cdp_swap_needed():
                 return  # CDP Mode is already active
@@ -4879,10 +4879,10 @@ class BaseCase(unittest.TestCase):
             current_url = self.get_current_url()
             if not current_url.startswith(("about", "data", "chrome")):
                 self.get_new_driver(undetectable=True)
-            self.driver.uc_open_with_cdp_mode(url)
+            self.driver.uc_open_with_cdp_mode(url, browser_executable_path)
         else:
             self.get_new_driver(undetectable=True)
-            self.driver.uc_open_with_cdp_mode(url)
+            self.driver.uc_open_with_cdp_mode(url, browser_executable_path)
         self.cdp = self.driver.cdp
 
     def activate_recorder(self):


### PR DESCRIPTION
I encountered a `FileNotFoundError` while working with SeleniumBase using Brave. It was caused by the `cdp_util.start( )` function because it could not find Chrome. By adding the `browser_executable_path` parameter in `activate_cdp_mode` and `uc_open_with_cdp_mode` i was able to easily resolve the unexpected behavior.

