### PR TITLE
Improve CDP memory usage

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.37.9"
+__version__ = "4.37.10"

--- a/seleniumbase/plugins/sb_manager.py
+++ b/seleniumbase/plugins/sb_manager.py
@@ -1369,12 +1369,15 @@ def SB(
                     "%s%s%s%s%s"
                     % (c1, left_space, end_text, right_space, cr)
                 )
-        if hasattr(sb_config, "_cdp_aclose"):
+        if undetectable and hasattr(sb, "_drivers_browser_map"):
             import asyncio
-            with suppress(Exception):
-                loop = asyncio.get_event_loop()
-                asyncio.set_event_loop(loop)
-                loop.run_until_complete(sb_config._cdp_aclose())
+            for driver in sb._drivers_browser_map.keys():
+                if hasattr(driver, "cdp") and driver.cdp:
+                    asyncio.set_event_loop(driver.cdp.loop)
+                    tasks = [tab.aclose() for tab in driver.cdp.get_tabs()]
+                    tasks.append(driver.cdp.driver.connection.aclose())
+                    driver.cdp.loop.run_until_complete(asyncio.gather(*tasks))
+                    driver.cdp.loop.close()
         gc.collect()
     if test and test_name and not test_passed and raise_test_failure:
         raise exception

--- a/seleniumbase/undetected/cdp_driver/connection.py
+++ b/seleniumbase/undetected/cdp_driver/connection.py
@@ -19,7 +19,6 @@ from typing import (
 )
 import websockets
 from websockets.protocol import State
-from seleniumbase import config as sb_config
 from . import cdp_util as util
 import mycdp as cdp
 import mycdp.network
@@ -271,7 +270,6 @@ class Connection(metaclass=CantTouchThis):
                     max_size=MAX_SIZE,
                 )
                 self.listener = Listener(self)
-                sb_config._cdp_aclose = self.aclose
             except (Exception,) as e:
                 logger.debug("Exception during opening of websocket: %s", e)
                 if self.listener:
@@ -446,7 +444,6 @@ class Connection(metaclass=CantTouchThis):
             if not _is_update:
                 await self._register_handlers()
             await self.websocket.send(tx.message)
-            sb_config._cdp_aclose = self.aclose
             try:
                 return await tx
             except ProtocolException as e:

--- a/seleniumbase/undetected/cdp_driver/tab.py
+++ b/seleniumbase/undetected/cdp_driver/tab.py
@@ -879,6 +879,7 @@ class Tab(Connection):
             await self.send(
                 cdp.target.close_target(target_id=self.target.target_id)
             )
+            await self.aclose()
             await asyncio.sleep(0.1)
 
     async def get_window(self) -> Tuple[


### PR DESCRIPTION
## Improve CDP memory usage
* [Improve CDP memory usage](https://github.com/seleniumbase/SeleniumBase/commit/e625c21fc7be567616cf6b0d19ab9f2ba573311f)

If you're spinning up a lot of CDP Mode web browsers in a loop within a Python file, then you'll use less memory because resources will get freed up at the end of the `with SB() as sb:` block, rather than after you've reached the end of the Python file (where regular garbage collection takes place).

Related discussion: https://github.com/seleniumbase/SeleniumBase/discussions/3679 - (Special thanks @felipehertzer)