### PR TITLE
Adding type hints to SB context manager

### DIFF
--- a/seleniumbase/plugins/sb_manager.py
+++ b/seleniumbase/plugins/sb_manager.py
@@ -24,6 +24,9 @@ with SB(uc=True) as sb:  # Many args! Eg. SB(browser="edge")
 #########################################
 """
 from contextlib import contextmanager, suppress
+from typing import Any, Generator
+
+from seleniumbase import BaseCase
 
 
 @contextmanager  # Usage: -> ``with SB() as sb:``
@@ -133,7 +136,7 @@ def SB(
     highlights=None,  # Number of highlight animations for Demo Mode actions.
     interval=None,  # SECONDS (Autoplay interval for SB Slides & Tour steps.)
     time_limit=None,  # SECONDS (Safely fail tests that exceed the time limit.)
-):
+) -> Generator[BaseCase, Any, None]:
     """
     * SeleniumBase as a Python Context Manager *
 


### PR DESCRIPTION
Related to #3167 and #3402.

This will have the same effect as:
```python
from seleniumbase import SB, BaseCase

sb: BaseCase
with SB(...) as sb:
    ...
```
without having to explicitly type `sb: BaseCase`, enabling IntelliSense in editors.
**Before:**
![image](https://github.com/user-attachments/assets/447cfd72-3398-415f-8c15-7a0af4ac8d6f)

**After:**
![image](https://github.com/user-attachments/assets/b60202cd-388c-4b2f-8368-f1254fcc0dee)
