### PR TITLE
Fix `load_cookies`, `add_cookie` & `add_cookies` behavior when `expiry=True`

### DIFF
--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -4608,7 +4608,7 @@ class BaseCase(unittest.TestCase):
                 del cookie["expiry"]
             elif isinstance(expiry, (int, float)) and expiry < 0:
                 pass
-            elif isinstance(expiry, (int, float)) and expiry > 0:
+            elif isinstance(expiry, (int, float)) and expiry > 0 and expiry is not True:
                 cookie["expiry"] = int(time.time()) + int(expiry * 60.0)
             elif expiry:
                 cookie["expiry"] = int(time.time()) + 86400

--- a/seleniumbase/fixtures/base_case.py
+++ b/seleniumbase/fixtures/base_case.py
@@ -4709,7 +4709,7 @@ class BaseCase(unittest.TestCase):
             del cookie["expiry"]
         elif isinstance(expiry, (int, float)) and expiry < 0:
             pass
-        elif isinstance(expiry, (int, float)) and expiry > 0:
+        elif isinstance(expiry, (int, float)) and expiry > 0 and expiry is not True:
             cookie["expiry"] = int(time.time()) + int(expiry * 60.0)
         elif expiry:
             cookie["expiry"] = int(time.time()) + 86400
@@ -4735,7 +4735,7 @@ class BaseCase(unittest.TestCase):
                 del cookie["expiry"]
             elif isinstance(expiry, (int, float)) and expiry < 0:
                 pass
-            elif isinstance(expiry, (int, float)) and expiry > 0:
+            elif isinstance(expiry, (int, float)) and expiry > 0 and expiry is not True:
                 cookie["expiry"] = int(time.time()) + int(expiry * 60.0)
             elif expiry:
                 cookie["expiry"] = int(time.time()) + 86400


### PR DESCRIPTION
The statement `isinstance(expiry, (int, float)) and expiry > 0` evaluates to `True` when `expiry=True` due to booleans being a subclass of integers in python: 
```python
print(isinstance(True, int))
>>> True
```

  
Please note that the same issue may cause some other parts to function unexpectedly, for example:
```
    def __get_type_checked_text(self, text):
        ...
        elif isinstance(text, (int, float)):
            return str(text)  # Convert num to string
        elif isinstance(text, bool):
            raise Exception("text must be a string! Boolean found!")
```
`isinstance(text, bool)` will never be reached and passing `text=True` or `text=False` will just return `"True"` or `"False"`