### PR TITLE
Fix debugger on Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pyyaml>=6.0.2
 pygments>=2.19.2
 pyreadline3>=3.5.3;platform_system=="Windows"
 tabcompleter>=1.4.0
-pdbp>=1.7.0
+pdbp>=1.7.1
 idna==3.10
 chardet==5.2.0
 charset-normalizer>=3.4.2,<4

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.40.3"
+__version__ = "4.40.4"

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ setup(
         'pygments>=2.19.2',
         'pyreadline3>=3.5.3;platform_system=="Windows"',
         "tabcompleter>=1.4.0",
-        "pdbp>=1.7.0",
+        "pdbp>=1.7.1",
         "idna==3.10",
         'chardet==5.2.0',
         'charset-normalizer>=3.4.2,<4',


### PR DESCRIPTION
## Fix debugger on Python 3.13
* [Refresh Python dependencies](https://github.com/seleniumbase/SeleniumBase/commit/fa34b634e89fa4b8aa548906956f9da1b06b037b)
--> This resolves https://github.com/seleniumbase/SeleniumBase/issues/3877