### PR TITLE
Add fallback for Chrome 142 removal of --load-extension

### DIFF
--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -2313,6 +2313,22 @@ def _set_chrome_options(
     device_pixel_ratio,
 ):
     chrome_options = webdriver.ChromeOptions()
+    
+    # Chrome 142+ removed support for --load-extension
+    # If a user passes this flag, warn them instead of failing.
+    for arg in list(getattr(sb_config, "chrome_args", [])):
+        if "--load-extension" in arg:
+            warnings.warn(
+                "Chrome 142 and above no longer support '--load-extension'. "
+                "This argument will be ignored.",
+                UserWarning,
+            )
+            # Remove the unsupported argument
+            try:
+                sb_config.chrome_args.remove(arg)
+            except Exception:
+                pass
+
     if is_using_uc(undetectable, browser_name):
         from seleniumbase import undetected
         chrome_options = undetected.ChromeOptions()


### PR DESCRIPTION
Summary--

Chrome 142 removed support for the --load-extension command-line flag.
If SeleniumBase users pass this flag manually, Chrome fails to start.

This PR adds safe handling:

1. Detects when --load-extension is passed
2. Warns the user that Chrome 142+ no longer supports it
3. Removes the flag so the browser launches correctly

What changed :

1. Added a detection loop and warning inside _set_chrome_options()
2. Removed unsupported flag before Chrome launch
3. Prevents unexpected browser launch failures
