### PR TITLE
CDP Mode: Patch 116

### DIFF
--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.49.11"
+__version__ = "4.49.12"

--- a/seleniumbase/undetected/cdp_driver/browser.py
+++ b/seleniumbase/undetected/cdp_driver/browser.py
@@ -502,7 +502,7 @@ class Browser:
                 ]
             ))
             time.sleep(0.02)
-            self.wait(0.02)
+            await self.wait(0.02)
             await connection.sleep(0.03)
         if _cdp_geolocation:
             await connection.set_geolocation(_cdp_geolocation)


### PR DESCRIPTION
## CDP Mode: Patch 116
* [Add missing await for async method call in CDP Mode](https://github.com/seleniumbase/SeleniumBase/pull/4389/commits/f87cf4f13a0e19fc360d7e8b98037dc79ec64da1)
-- This resolves https://github.com/seleniumbase/SeleniumBase/issues/4388
-- (Applies to setting `ad_block=True` in CDP Mode)