### PR TITLE
Fix Brave and Opera automation

### DIFF
--- a/mkdocs_build/requirements.txt
+++ b/mkdocs_build/requirements.txt
@@ -3,7 +3,7 @@
 
 regex>=2026.6.28
 pymdown-extensions>=10.21.3
-pipdeptree>=3.1.0
+pipdeptree>=3.1.1
 python-dateutil>=2.8.2
 click>=8.4.2
 Markdown==3.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,13 @@ exceptiongroup>=1.3.1
 websockets~=15.0.1;python_version<"3.10"
 websockets>=16.0;python_version>="3.10"
 filelock~=3.19.1;python_version<"3.10"
-filelock>=3.29.4;python_version>="3.10"
+filelock>=3.29.5;python_version>="3.10"
 fasteners>=0.20
 mycdp>=1.4.0
 pynose>=1.5.5
 platformdirs~=4.4.0;python_version<"3.10"
 platformdirs>=4.10.0;python_version>="3.10"
-typing-extensions>=4.15.0
+typing-extensions>=4.16.0
 sbvirtualdisplay>=1.4.0
 MarkupSafe>=3.0.3
 Jinja2>=3.1.6
@@ -61,7 +61,8 @@ pytest-html==4.0.2
 pytest-metadata==3.1.1
 pytest-ordering==0.6
 pytest-rerunfailures==16.0.1;python_version<"3.10"
-pytest-rerunfailures==16.3;python_version>="3.10"
+pytest-rerunfailures==16.3;python_version=="3.10"
+pytest-rerunfailures==16.4;python_version>="3.11"
 pytest-xdist==3.8.0
 parameterized==0.9.0
 behave==1.2.6
@@ -79,7 +80,7 @@ rich>=15.0.0,<16
 # ("pip install -r requirements.txt" also installs this, but "pip install -e ." won't.)
 
 coverage>=7.10.7;python_version<"3.10"
-coverage>=7.14.3;python_version>="3.10"
+coverage>=7.15.0;python_version>="3.10"
 pytest-cov>=7.1.0
 flake8==7.3.0
 mccabe==0.7.0

--- a/seleniumbase/__version__.py
+++ b/seleniumbase/__version__.py
@@ -1,2 +1,2 @@
 # seleniumbase package
-__version__ = "4.50.4"
+__version__ = "4.50.5"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -5157,6 +5157,13 @@ def get_local_driver(
                     sb_config.multi_proxy = True
                 if uc_driver_version and driver_version == "keep":
                     driver_version = uc_driver_version
+            if (
+                hasattr(sb_config, "_cdp_browser")
+                and sb_config._cdp_browser == "opera"
+            ):
+                use_version = "132"
+                if use_uc:
+                    use_version = "144"
             use_version = find_chromedriver_version_to_use(
                 use_version, driver_version
             )

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -2816,7 +2816,13 @@ def _set_chrome_options(
     d_f_string = ",".join(included_disabled_features)
     chrome_options.add_argument("--disable-features=%s" % d_f_string)
     chrome_options.add_argument("--enable-unsafe-extension-debugging")
-    chrome_options.add_argument("--test-type")
+    if (
+        hasattr(sb_config, "_cdp_browser")
+        and sb_config._cdp_browser == "brave"
+    ):
+        pass  # Looks like "--test-type" breaks Brave now
+    else:
+        chrome_options.add_argument("--test-type")
     if proxy_auth or sb_config._ext_dirs:
         if not is_using_uc(undetectable, browser_name):
             chrome_options.add_argument("--remote-debugging-pipe")
@@ -3120,6 +3126,11 @@ def get_driver(
     if browser_name in constants.ChromiumSubs.chromium_subs:
         browser_name = "chrome"
     browser_name = browser_name.lower()
+    if (
+        hasattr(sb_config, "_cdp_browser")
+        and sb_config._cdp_browser == "brave"
+    ):
+        undetectable = True
     if is_using_uc(undetectable, browser_name):
         if ad_block_on:
             sb_config.ad_block_on = True

--- a/seleniumbase/undetected/cdp_driver/config.py
+++ b/seleniumbase/undetected/cdp_driver/config.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import zipfile
 from contextlib import suppress
+from seleniumbase import config as sb_config
 from seleniumbase.config import settings
 from seleniumbase.drivers import cft_drivers
 from seleniumbase.drivers import chromium_drivers
@@ -238,12 +239,10 @@ class Config:
             "--enable-privacy-sandbox-ads-apis",
             "--safebrowsing-disable-download-protection",
             '--simulate-outdated-no-au="Tue, 31 Dec 2099 23:59:59 GMT"',
-            "--test-type",
             "--ash-no-nudges",
             "--password-store=basic",
             "--deny-permission-prompts",
             "--disable-breakpad",
-            "--disable-setuid-sandbox",
             "--disable-prompt-on-repost",
             "--disable-application-cache",
             "--disable-password-generation",
@@ -262,6 +261,15 @@ class Config:
             "--disable-renderer-backgrounding",
             "--disable-dev-shm-usage",
         ]
+        if (
+            hasattr(sb_config, "_cdp_browser")
+            and sb_config._cdp_browser == "brave"
+        ):
+            pass  # Looks like "--test-type" breaks Brave now
+        else:
+            self._default_browser_args.append("--test-type")
+        if IS_LINUX:
+            self._default_browser_args.append("--disable-setuid-sandbox")
         if mock_keychain:
             self._default_browser_args.append("--use-mock-keychain")
 

--- a/setup.py
+++ b/setup.py
@@ -174,13 +174,13 @@ setup(
         'websockets~=15.0.1;python_version<"3.10"',
         'websockets>=16.0;python_version>="3.10"',
         'filelock~=3.19.1;python_version<"3.10"',
-        'filelock>=3.29.4;python_version>="3.10"',
+        'filelock>=3.29.5;python_version>="3.10"',
         'fasteners>=0.20',
         'mycdp>=1.4.0',
         'pynose>=1.5.5',
         'platformdirs~=4.4.0;python_version<"3.10"',
         'platformdirs>=4.10.0;python_version>="3.10"',
-        'typing-extensions>=4.15.0',
+        'typing-extensions>=4.16.0',
         'sbvirtualdisplay>=1.4.0',
         'MarkupSafe>=3.0.3',
         'Jinja2>=3.1.6',
@@ -225,7 +225,8 @@ setup(
         'pytest-metadata==3.1.1',
         'pytest-ordering==0.6',
         'pytest-rerunfailures==16.0.1;python_version<"3.10"',
-        'pytest-rerunfailures==16.3;python_version>="3.10"',
+        'pytest-rerunfailures==16.3;python_version=="3.10"',
+        'pytest-rerunfailures==16.4;python_version>="3.11"',
         'pytest-xdist==3.8.0',
         'parameterized==0.9.0',
         'behave==1.2.6',  # Newer ones had issues
@@ -252,7 +253,7 @@ setup(
         # Usage: coverage run -m pytest; coverage html; coverage report
         "coverage": [
             'coverage>=7.10.7;python_version<"3.10"',
-            'coverage>=7.14.3;python_version>="3.10"',
+            'coverage>=7.15.0;python_version>="3.10"',
             'pytest-cov>=7.1.0',
         ],
         # pip install -e .[flake8]
@@ -282,7 +283,7 @@ setup(
         # (An optional library for image-processing.)
         "pillow": [
             'Pillow>=11.3.0;python_version<"3.10"',
-            'Pillow>=12.2.0;python_version>="3.10"',
+            'Pillow>=12.3.0;python_version>="3.10"',
         ],
         # pip install -e .[pip-system-certs]
         # (If you see [SSL: CERTIFICATE_VERIFY_FAILED], then get this.)


### PR DESCRIPTION
## Fix Brave and Opera automation
* [Fix Brave Browser automation](https://github.com/seleniumbase/SeleniumBase/commit/c41948eab2d4e8a981e783042bf2f49ef4079de7)
* [Fix Opera Browser automation](https://github.com/seleniumbase/SeleniumBase/commit/2632525f3b16313cc00cd6c068cf22dfbbce7be6)
* [Refresh Python dependencies](https://github.com/seleniumbase/SeleniumBase/commit/308e71fca644ea7a896f17e4b65d77e4c807a0f6)

### More info:
* The `--test-type` arg started breaking Brave on version 150. It's no longer used if Brave is set.
* Brave with regular Chromedriver stopped worked. Since it works with UC, that mode is forced.
* Opera Browser now needs specific versions of Chromedriver and UC. (Those versions are set.)