### PR TITLE
Add REMOTE_WEBDRIVER_TIMEOUT setting for Remote WebDriver HTTP requests

### DIFF
--- a/seleniumbase/config/settings.py
+++ b/seleniumbase/config/settings.py
@@ -23,6 +23,14 @@ EXTREME_TIMEOUT = 30
 # In global Selenium settings, this value is set to 300 seconds by default.
 PAGE_LOAD_TIMEOUT = 120
 
+# Default client-side timeout (in seconds) for each HTTP request that a
+# Remote WebDriver client sends to a Selenium server / Selenium Grid.
+# When set to None, requests have no client-side timeout, which means
+# a WebDriver command can block forever if a grid node dies mid-session.
+# If used, set this higher than PAGE_LOAD_TIMEOUT, and higher than the
+# time a new-session request may wait in your grid's session queue.
+REMOTE_WEBDRIVER_TIMEOUT = None
+
 # Default page load strategy.
 # ["normal", "eager", "none"]
 # Selenium default = "normal"

--- a/seleniumbase/core/browser_launcher.py
+++ b/seleniumbase/core/browser_launcher.py
@@ -19,6 +19,7 @@ from selenium.common.exceptions import InvalidSessionIdException
 from selenium.common.exceptions import SessionNotCreatedException
 from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.common import utils as common_utils
+from selenium.webdriver.remote.client_config import ClientConfig
 from seleniumbase import config as sb_config
 from seleniumbase import decorators
 from seleniumbase import drivers  # webdriver storage folder for SeleniumBase
@@ -3719,6 +3720,12 @@ def get_remote_driver(
             address += "wd/hub"
         else:
             address += "/wd/hub"
+    client_config = None
+    if settings.REMOTE_WEBDRIVER_TIMEOUT:
+        client_config = ClientConfig(
+            remote_server_addr=address,
+            timeout=settings.REMOTE_WEBDRIVER_TIMEOUT,
+        )
     downloads_path = DOWNLOADS_FOLDER
     desired_caps = {}
     extra_caps = {}
@@ -3845,6 +3852,7 @@ def get_remote_driver(
                 chrome_options.set_capability(key, ext_caps[key])
         driver = webdriver.Remote(
             command_executor=address,
+            client_config=client_config,
             options=chrome_options,
         )
         return extend_driver(driver)
@@ -3910,6 +3918,7 @@ def get_remote_driver(
                 firefox_options.set_capability(key, ext_caps[key])
         driver = webdriver.Remote(
             command_executor=address,
+            client_config=client_config,
             options=firefox_options,
         )
         return extend_driver(driver)
@@ -3919,6 +3928,7 @@ def get_remote_driver(
         remote_options.set_capability("cloud:options", desired_caps)
         driver = webdriver.Remote(
             command_executor=address,
+            client_config=client_config,
             options=remote_options,
         )
         return extend_driver(driver)
@@ -4018,6 +4028,7 @@ def get_remote_driver(
                 edge_options.set_capability(key, ext_caps[key])
         driver = webdriver.Remote(
             command_executor=address,
+            client_config=client_config,
             options=edge_options,
         )
         return extend_driver(driver)
@@ -4027,6 +4038,7 @@ def get_remote_driver(
         remote_options.set_capability("cloud:options", desired_caps)
         driver = webdriver.Remote(
             command_executor=address,
+            client_config=client_config,
             options=remote_options,
         )
         return extend_driver(driver)
@@ -4039,6 +4051,7 @@ def get_remote_driver(
             remote_options.set_capability("bstack:options", desired_caps)
         driver = webdriver.Remote(
             command_executor=address,
+            client_config=client_config,
             options=remote_options,
         )
         return extend_driver(driver)

--- a/seleniumbase/core/settings_parser.py
+++ b/seleniumbase/core/settings_parser.py
@@ -73,6 +73,8 @@ def set_settings(settings_file):
             settings.EXTREME_TIMEOUT = override_settings[key]
         elif key == "PAGE_LOAD_TIMEOUT":
             settings.PAGE_LOAD_TIMEOUT = override_settings[key]
+        elif key == "REMOTE_WEBDRIVER_TIMEOUT":
+            settings.REMOTE_WEBDRIVER_TIMEOUT = override_settings[key]
         elif key == "ARCHIVE_EXISTING_LOGS":
             settings.ARCHIVE_EXISTING_LOGS = override_settings[key]
         elif key == "ARCHIVE_EXISTING_DOWNLOADS":


### PR DESCRIPTION
AI disclosure: I have been trying to pin down our node failures for a while now manually and with our selenium grid provider, but it is infrequent enough to be hard to pin down why they occur (and since they spin up AWS nodes on-demand, a lot of it is out of their control anyway). In an effort to avoid our tests running until our final-line-of-defense of the timeout in pytest-timeout plugin, I've leveraged Claude Code to diagnose this and suggest solutions. I have personally read through these changes and have a decent understanding, and believe this should be a safe setting to pass through to Selenium's RemoteWebDriver. 

--- 

Add a REMOTE_WEBDRIVER_TIMEOUT setting (default None, which keeps the existing behavior). When set, get_remote_driver() builds a ClientConfig with that timeout and passes it to webdriver.Remote, so every HTTP request to the remote server gets a finite client-side deadline and a dead node surfaces as a ReadTimeoutError instead of an infinite hang. The setting matches other settings consumed via --settings-file.

Sizing guidance: set the value above PAGE_LOAD_TIMEOUT (a page navigation legitimately holds one request open that long) and above the time a new-session request may wait in the grid's session queue.

Selenium's ClientConfig defaults its HTTP timeout to socket.getdefaulttimeout(), which is None unless the application sets a process-wide socket default (which is rare), so a WebDriver command to a remote Selenium server blocks forever if a grid node dies with the TCP connection half-open. 

Verified against a TCP server that accepts connections and never responds (simulating a dead node): with REMOTE_WEBDRIVER_TIMEOUT = 5, Driver(browser="chrome", server="127.0.0.1", port=5555) raises ReadTimeoutError ... (read timeout=5) after 5.0s. With the default (None), it blocks indefinitely — existing behavior is unchanged.

Also verified against a real Selenium Grid provider (Gridlastic): with selenium grid nodes warm (up, but not in use, ready for a new runner) and the setting intentionally at an extremely low setting of 2 seconds, a live session-creation request fails with ReadTimeoutError mid-queue as expected, and with the setting at 10 seconds, a 16-test run against warm grid nodes passes with zero false timeouts — every healthy request answered well inside even that aggressive ceiling. The default for real use should be generous (above PAGE_LOAD_TIMEOUT and the grid's new-session queue wait, which Gridlastic recommends a normal wait time being 3-5 minutes, with their maximum being 10 minutes); we would run REMOTE_WEBDRIVER_TIMEOUT at 660s. It is still basically a 'last line of defense' as far as the grid health is concerned, and we'll leave pytest-timeout as the true 'last line of defense'. 

flake8 clean on the three touched files.

Also as a side note, `remote_server_addr=address` is set only because it is required for `ClientConfig`, even though Selenium's `get_remote_connection` sets it again, see https://github.com/SeleniumHQ/selenium/blob/5b3666d62507b79ae08b0bf0e18604c28bb8f404/py/selenium/webdriver/remote/webdriver.py#L113-L114